### PR TITLE
fix SetGranularity and example

### DIFF
--- a/builder/granularity/simple.go
+++ b/builder/granularity/simple.go
@@ -23,8 +23,9 @@ func (s *Simple) Type() builder.ComponentType {
 	return "simple"
 }
 
-func (s *Simple) SetGranularity(g Simple) {
+func (s *Simple) SetGranularity(g Simple) *Simple {
 	*s = g
+	return s
 }
 
 func NewSimple() *Simple {

--- a/examples/main.go
+++ b/examples/main.go
@@ -12,7 +12,6 @@ import (
 	"github.com/grafadruid/go-druid/builder/datasource"
 	"github.com/grafadruid/go-druid/builder/filter"
 	"github.com/grafadruid/go-druid/builder/granularity"
-	"github.com/grafadruid/go-druid/builder/limitspec"
 	"github.com/grafadruid/go-druid/builder/query"
 	"github.com/grafadruid/go-druid/builder/types"
 )
@@ -29,14 +28,12 @@ func main() {
 	fmt.Println("{\"version\": \"" + status.Version + "\"}")
 
 	t := datasource.NewTable().SetName("wikipedia")
-	i := types.NewInterval(time.Now().Add(-10*time.Hour), time.Now())
+	i := types.NewInterval(time.Unix(0, 0), time.Now())
 	c := aggregation.NewCount().SetName("count")
 	aa := []builder.Aggregator{c}
 	s := filter.NewSelector().SetDimension("country").SetValue("France")
 	m := granularity.NewSimple().SetGranularity(granularity.Minute)
-	l := limitspec.NewDefault().SetLimit(10)
-	ts := query.NewTimeseries().SetDatasource(t).SetInterval(i).SetAggregations(aa).SetGranularity(m).SetFilter(s).SetLimit(l)
-
+	ts := query.NewTimeseries().SetDataSource(t).SetIntervals([]types.Interval{i}).SetAggregations(aa).SetGranularity(m).SetFilter(s).SetLimit(10)
 	var results interface{}
 	d.Query().Execute(ts, &results)
 	spew.Dump(results)


### PR DESCRIPTION
* fix SetGranularity
* fix the example 
  * use unix 0 to get data else interval is out of the data boundary
  * `SetLimit` takes int64 (not a builder)