### PR TITLE
marshal intervals using the short spec variant

### DIFF
--- a/builder/intervals/default.go
+++ b/builder/intervals/default.go
@@ -1,5 +1,7 @@
 package intervals
 
+import "encoding/json"
+
 type Intervals struct {
 	Base
 	Intervals []*Interval `json:"intervals,omitempty"`
@@ -14,4 +16,8 @@ func NewIntervals() *Intervals {
 func (i *Intervals) SetIntervals(intervals []*Interval) *Intervals {
 	i.Intervals = intervals
 	return i
+}
+
+func (i *Intervals) MarshalJSON() ([]byte, error) {
+	return json.Marshal(i.Intervals)
 }


### PR DESCRIPTION
Looks like Druid supports only the short intervals spec variant for intervals filter. Always marshaling that way then.