### PR TITLE
Add HLLSketch aggregator

### DIFF
--- a/builder/aggregation/aggregation.go
+++ b/builder/aggregation/aggregation.go
@@ -72,6 +72,10 @@ func Load(data []byte) (builder.Aggregator, error) {
 		a = NewFloatSum()
 	case "histogram":
 		a = NewHistogram()
+	case "HLLSketchBuild":
+		a = NewHLLSketchBuild()
+	case "HLLSketchMerge":
+		a = NewHLLSketchMerge()
 	case "hyperUnique":
 		a = NewHyperUnique()
 	case "javascript":

--- a/builder/aggregation/hll_sketch.go
+++ b/builder/aggregation/hll_sketch.go
@@ -6,7 +6,7 @@ type HLLSketch struct {
 	Base
 	FieldName  string `json:"fieldName,omitempty"`
 	LgK        int64  `json:"lgK,omitempty"`
-	TgtHllType string `json:"tgtHllType,omitempty"`
+	TgtHLLType string `json:"tgtHllType,omitempty"`
 	Round      bool   `json:"round,omitempty"`
 }
 
@@ -43,8 +43,8 @@ func (t *HLLSketch) SetLgK(lgk int64) *HLLSketch {
 }
 
 // SetTgtHllType set tgtHllType
-func (t *HLLSketch) SetTgtHllType(tgtHllType string) *HLLSketch {
-	t.TgtHllType = tgtHllType
+func (t *HLLSketch) SetTgtHLLType(tgtHLLType string) *HLLSketch {
+	t.TgtHLLType = tgtHLLType
 	return t
 }
 

--- a/builder/aggregation/hll_sketch.go
+++ b/builder/aggregation/hll_sketch.go
@@ -1,0 +1,55 @@
+package aggregation
+
+// HLLSketch holds the HLL sketch struct based on
+// Aggregator section in https://druid.apache.org/docs/latest/development/extensions-core/datasketches-hll.html
+type HLLSketch struct {
+	Base
+	FieldName  string `json:"fieldName,omitempty"`
+	LgK        int64  `json:"lgK,omitempty"`
+	TgtHllType string `json:"tgtHllType,omitempty"`
+	Round      bool   `json:"round,omitempty"`
+}
+
+// NewHLLSketchBuild create a new instance of HLLSketch with type HLLSketchBuild
+func NewHLLSketchBuild() *HLLSketch {
+	t := &HLLSketch{}
+	t.Base.SetType("HLLSketchBuild")
+	return t
+}
+
+// NewHLLSketchMerge create a new instance of HLLSketch with type HLLSketchMerge
+func NewHLLSketchMerge() *HLLSketch {
+	t := &HLLSketch{}
+	t.Base.SetType("HLLSketchMerge")
+	return t
+}
+
+// SetName set name
+func (t *HLLSketch) SetName(name string) *HLLSketch {
+	t.Base.SetName(name)
+	return t
+}
+
+// SetFieldName set fieldName
+func (t *HLLSketch) SetFieldName(fieldName string) *HLLSketch {
+	t.FieldName = fieldName
+	return t
+}
+
+// SetLgK set lgK. The value needs to be in the [4, 21] range
+func (t *HLLSketch) SetLgK(lgk int64) *HLLSketch {
+	t.LgK = lgk
+	return t
+}
+
+// SetTgtHllType set tgtHllType
+func (t *HLLSketch) SetTgtHllType(tgtHllType string) *HLLSketch {
+	t.TgtHllType = tgtHllType
+	return t
+}
+
+// SetRound set round.
+func (t *HLLSketch) SetRound(round bool) *HLLSketch {
+	t.Round = round
+	return t
+}

--- a/builder/aggregation/hll_sketch_test.go
+++ b/builder/aggregation/hll_sketch_test.go
@@ -1,0 +1,32 @@
+package aggregation
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHLLSketchBuild(t *testing.T) {
+	hllSketch := NewHLLSketchBuild()
+	hllSketch.SetName("output_name").SetFieldName("metric_name").SetLgK(5).SetTgtHllType("HLL_6")
+
+	// "omitempty" will ignore boolean=false
+	expected := `{"type":"HLLSketchBuild", "name":"output_name", "fieldName": "metric_name", "lgK":5, "tgtHllType":"HLL_6"}`
+
+	hllSketchJson, err := json.Marshal(hllSketch)
+	assert.Nil(t, err)
+	assert.JSONEq(t, expected, string(hllSketchJson))
+}
+
+func TestHLLSketchMerge(t *testing.T) {
+	hllSketch := NewHLLSketchMerge()
+	hllSketch.SetName("output_name").SetFieldName("metric_name").SetLgK(5).SetTgtHllType("HLL_6")
+
+	// "omitempty" will ignore boolean=false
+	expected := `{"type":"HLLSketchMerge", "name":"output_name",  "fieldName": "metric_name", "lgK":5, "tgtHllType":"HLL_6"}`
+
+	hllSketchJson, err := json.Marshal(hllSketch)
+	assert.Nil(t, err)
+	assert.JSONEq(t, expected, string(hllSketchJson))
+}

--- a/builder/aggregation/hll_sketch_test.go
+++ b/builder/aggregation/hll_sketch_test.go
@@ -9,24 +9,24 @@ import (
 
 func TestHLLSketchBuild(t *testing.T) {
 	hllSketch := NewHLLSketchBuild()
-	hllSketch.SetName("output_name").SetFieldName("metric_name").SetLgK(5).SetTgtHllType("HLL_6")
+	hllSketch.SetName("output_name").SetFieldName("metric_name").SetLgK(5).SetTgtHLLType("HLL_6")
 
 	// "omitempty" will ignore boolean=false
 	expected := `{"type":"HLLSketchBuild", "name":"output_name", "fieldName": "metric_name", "lgK":5, "tgtHllType":"HLL_6"}`
 
-	hllSketchJson, err := json.Marshal(hllSketch)
+	hllSketchJSON, err := json.Marshal(hllSketch)
 	assert.Nil(t, err)
-	assert.JSONEq(t, expected, string(hllSketchJson))
+	assert.JSONEq(t, expected, string(hllSketchJSON))
 }
 
 func TestHLLSketchMerge(t *testing.T) {
 	hllSketch := NewHLLSketchMerge()
-	hllSketch.SetName("output_name").SetFieldName("metric_name").SetLgK(5).SetTgtHllType("HLL_6")
+	hllSketch.SetName("output_name").SetFieldName("metric_name").SetLgK(5).SetTgtHLLType("HLL_6")
 
 	// "omitempty" will ignore boolean=false
 	expected := `{"type":"HLLSketchMerge", "name":"output_name",  "fieldName": "metric_name", "lgK":5, "tgtHllType":"HLL_6"}`
 
-	hllSketchJson, err := json.Marshal(hllSketch)
+	hllSketchJSON, err := json.Marshal(hllSketch)
 	assert.Nil(t, err)
-	assert.JSONEq(t, expected, string(hllSketchJson))
+	assert.JSONEq(t, expected, string(hllSketchJSON))
 }

--- a/builder/aggregation/thetasketch.go
+++ b/builder/aggregation/thetasketch.go
@@ -6,7 +6,7 @@ type ThetaSketch struct {
 	Base
 	FieldName          string `json:"fieldName,omitempty"`
 	IsInputThetaSketch bool   `json:"isInputThetaSketch,omitempty"`
-	Size               int64  `json:"size, omitempty"`
+	Size               int64  `json:"size,omitempty"`
 }
 
 // NewThetaSketch create a new instance of ThetaSketch

--- a/builder/aggregation/thetasketch_test.go
+++ b/builder/aggregation/thetasketch_test.go
@@ -2,8 +2,9 @@ package aggregation
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestThetaSketch(t *testing.T) {
@@ -13,7 +14,7 @@ func TestThetaSketch(t *testing.T) {
 	// "omitempty" will ignore boolean=false
 	expected := `{"type":"thetaSketch", "name":"output_name", "fieldName":"metric_name", "size":16384}`
 
-	thetaSketchJson, err := json.Marshal(thetaSketch)
+	thetaSketchJSON, err := json.Marshal(thetaSketch)
 	assert.Nil(t, err)
-	assert.JSONEq(t, expected, string(thetaSketchJson))
+	assert.JSONEq(t, expected, string(thetaSketchJSON))
 }


### PR DESCRIPTION
Adding the [HLLSketch aggregator](https://druid.apache.org/docs/latest/development/extensions-core/datasketches-hll.html).

Sorry to mix the small fix on `thetaSketch`, I can put that into a separate PR if required. That extra space there was caught by `go vet` and actually makes the `omitempty` not work.