### PR TITLE
Add Base method to dimension lookup

### DIFF
--- a/builder/dimension/lookup.go
+++ b/builder/dimension/lookup.go
@@ -32,6 +32,11 @@ func (l *Lookup) SetName(name string) *Lookup {
 	return l
 }
 
+func (l *Lookup) SetOutputName(outputName string) *Lookup {
+	l.Base.SetOutputName(outputName)
+	return l
+}
+
 func (l *Lookup) SetReplaceMissingValueWith(replaceMissingValueWith string) *Lookup {
 	l.ReplaceMissingValueWith = replaceMissingValueWith
 	return l

--- a/builder/dimension/lookup_test.go
+++ b/builder/dimension/lookup_test.go
@@ -1,0 +1,19 @@
+package dimension
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDimensionLookup(t *testing.T) {
+	lookup := NewLookup().SetOutputName("output_name").SetName("lookup_name").SetRetainMissingValue(true)
+
+	// "omitempty" will ignore boolean=false
+	expected := `{"name":"lookup_name", "outputName":"output_name", "retainMissingValue":true, "type":"lookup"}`
+
+	lookupJSON, err := json.Marshal(lookup)
+	assert.Nil(t, err)
+	assert.JSONEq(t, expected, string(lookupJSON))
+}


### PR DESCRIPTION
This is a fix so that chaining works properly with the `dimension.Lookup` type.

Currently, this works for example:
```golang
NewLookup().SetRetainMissingValue(true).SetOutputName("output_name")
```
But this doesn't:
```golang
NewLookup().SetOutputName("output_name").SetRetainMissingValue(true)
```

That's because `SetOutputName` is not defined directly in `dimension.Lookup`, so the one defined in `dimension.Base` ends up being called instead.