### PR TITLE
Add registered lookup extraction function

### DIFF
--- a/builder/extractionfn/extraction_fn.go
+++ b/builder/extractionfn/extraction_fn.go
@@ -48,6 +48,8 @@ func Load(data []byte) (builder.ExtractionFn, error) {
 		e = NewPartial()
 	case "regex":
 		e = NewRegex()
+	case "registeredLookup":
+		e = NewRegisteredLookup()
 	case "searchQuery":
 		e = NewSearchQuery()
 	case "stringFormat":

--- a/builder/extractionfn/registered_lookup.go
+++ b/builder/extractionfn/registered_lookup.go
@@ -1,0 +1,43 @@
+package extractionfn
+
+// RegisteredLookup holds the registered lookup extraction function struct based on
+// https://druid.apache.org/docs/latest/querying/dimensionspecs.html#registered-lookup-extraction-function
+type RegisteredLookup struct {
+	Base
+	Lookup                  string `json:"lookup,omitempty"`
+	RetainMissingValue      bool   `json:"retainMissingValue,omitempty"`
+	ReplaceMissingValueWith string `json:"replaceMissingValueWith,omitempty"`
+	Injective               *bool  `json:"injective,omitempty"` // Use *bool to differentiate between missing value and false
+	Optimize                *bool  `json:"optimize,omitempty"`  // Use *bool to differentiate between missing value and false
+}
+
+func NewRegisteredLookup() *RegisteredLookup {
+	l := &RegisteredLookup{}
+	l.SetType("registeredLookup")
+	return l
+}
+
+func (l *RegisteredLookup) SetLookup(lookup string) *RegisteredLookup {
+	l.Lookup = lookup
+	return l
+}
+
+func (l *RegisteredLookup) SetRetainMissingValue(retainMissingValue bool) *RegisteredLookup {
+	l.RetainMissingValue = retainMissingValue
+	return l
+}
+
+func (l *RegisteredLookup) SetReplaceMissingValueWith(replaceMissingValueWith string) *RegisteredLookup {
+	l.ReplaceMissingValueWith = replaceMissingValueWith
+	return l
+}
+
+func (l *RegisteredLookup) SetInjective(injective bool) *RegisteredLookup {
+	l.Injective = &injective
+	return l
+}
+
+func (l *RegisteredLookup) SetOptimize(optimize bool) *RegisteredLookup {
+	l.Optimize = &optimize
+	return l
+}

--- a/builder/extractionfn/registered_lookup_test.go
+++ b/builder/extractionfn/registered_lookup_test.go
@@ -1,0 +1,20 @@
+package extractionfn
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisteredLookupExtractionFn(t *testing.T) {
+	lookup := NewRegisteredLookup()
+	lookup.SetLookup("my_lookup").SetOptimize(false).SetReplaceMissingValueWith("N/A")
+
+	// it's important that 'false' values are not omitted in the 'injective' and 'optimize' fields.
+	expected := `{"type":"registeredLookup", "lookup":"my_lookup", "optimize":false, "replaceMissingValueWith":"N/A"}`
+
+	lookupJSON, err := json.Marshal(lookup)
+	assert.Nil(t, err)
+	assert.JSONEq(t, expected, string(lookupJSON))
+}


### PR DESCRIPTION
Note that `Injective` and `Optimize` are of type `*bool`. This is so they are included in the outgoing JSON even when they're set to `false`, but are still not included if their values is not set.

As detailed [here](https://druid.apache.org/docs/latest/querying/dimensionspecs.html#registered-lookup-extraction-function):
> A property of injective can override the lookup's own sense of whether or not it is injective. If left unspecified, Druid will use the registered cluster-wide lookup configuration.

and
> A property optimize can be supplied to allow optimization of lookup based extraction filter (by default optimize = true).

Therefore, it's important to distinguish between those fields missing and explicitly set to `false`.