### PR TITLE
Use bool pointers when building JSON requests

### DIFF
--- a/builder/aggregation/cardinality.go
+++ b/builder/aggregation/cardinality.go
@@ -3,8 +3,8 @@ package aggregation
 type Cardinality struct {
 	Base
 	Fields []string `json:"fields,omitempty"`
-	ByRow  bool     `json:"byRow,omitempty"`
-	Round  bool     `json:"round,omitempty"`
+	ByRow  *bool    `json:"byRow,omitempty"`
+	Round  *bool    `json:"round,omitempty"`
 }
 
 func NewCardinality() *Cardinality {
@@ -24,11 +24,11 @@ func (c *Cardinality) SetFields(fields []string) *Cardinality {
 }
 
 func (c *Cardinality) SetByRow(byRow bool) *Cardinality {
-	c.ByRow = byRow
+	c.ByRow = &byRow
 	return c
 }
 
 func (c *Cardinality) SetRound(round bool) *Cardinality {
-	c.Round = round
+	c.Round = &round
 	return c
 }

--- a/builder/aggregation/hll_sketch.go
+++ b/builder/aggregation/hll_sketch.go
@@ -7,7 +7,7 @@ type HLLSketch struct {
 	FieldName  string `json:"fieldName,omitempty"`
 	LgK        int64  `json:"lgK,omitempty"`
 	TgtHLLType string `json:"tgtHllType,omitempty"`
-	Round      bool   `json:"round,omitempty"`
+	Round      *bool  `json:"round,omitempty"`
 }
 
 // NewHLLSketchBuild create a new instance of HLLSketch with type HLLSketchBuild
@@ -50,6 +50,6 @@ func (t *HLLSketch) SetTgtHLLType(tgtHLLType string) *HLLSketch {
 
 // SetRound set round.
 func (t *HLLSketch) SetRound(round bool) *HLLSketch {
-	t.Round = round
+	t.Round = &round
 	return t
 }

--- a/builder/aggregation/hyper_unique.go
+++ b/builder/aggregation/hyper_unique.go
@@ -3,8 +3,8 @@ package aggregation
 type HyperUnique struct {
 	Base
 	FieldName          string `json:"fieldName,omitempty"`
-	IsInputHyperUnique bool   `json:"isInputHyperUnique,omitempty"`
-	Round              bool   `json:"round,omitempty"`
+	IsInputHyperUnique *bool  `json:"isInputHyperUnique,omitempty"`
+	Round              *bool  `json:"round,omitempty"`
 }
 
 func NewHyperUnique() *HyperUnique {
@@ -24,11 +24,11 @@ func (h *HyperUnique) SetFieldName(fieldName string) *HyperUnique {
 }
 
 func (h *HyperUnique) SetIsInputHyperUnique(isInputHyperUnique bool) *HyperUnique {
-	h.IsInputHyperUnique = isInputHyperUnique
+	h.IsInputHyperUnique = &isInputHyperUnique
 	return h
 }
 
 func (h *HyperUnique) SetRound(round bool) *HyperUnique {
-	h.Round = round
+	h.Round = &round
 	return h
 }

--- a/builder/aggregation/thetasketch.go
+++ b/builder/aggregation/thetasketch.go
@@ -5,7 +5,7 @@ package aggregation
 type ThetaSketch struct {
 	Base
 	FieldName          string `json:"fieldName,omitempty"`
-	IsInputThetaSketch bool   `json:"isInputThetaSketch,omitempty"`
+	IsInputThetaSketch *bool  `json:"isInputThetaSketch,omitempty"`
 	Size               int64  `json:"size,omitempty"`
 }
 
@@ -30,7 +30,7 @@ func (t *ThetaSketch) SetFieldName(fieldName string) *ThetaSketch {
 
 // SetIsInputThetaSketch set theta isInputThetaSketch
 func (t *ThetaSketch) SetIsInputThetaSketch(isInputThetaSketch bool) *ThetaSketch {
-	t.IsInputThetaSketch = isInputThetaSketch
+	t.IsInputThetaSketch = &isInputThetaSketch
 	return t
 }
 

--- a/builder/aggregation/thetasketch_test.go
+++ b/builder/aggregation/thetasketch_test.go
@@ -12,7 +12,7 @@ func TestThetaSketch(t *testing.T) {
 	thetaSketch.SetName("output_name").SetFieldName("metric_name").SetIsInputThetaSketch(false).SetSize(16384)
 
 	// "omitempty" will ignore boolean=false
-	expected := `{"type":"thetaSketch", "name":"output_name", "fieldName":"metric_name", "size":16384}`
+	expected := `{"type":"thetaSketch", "isInputThetaSketch":false, "name":"output_name", "fieldName":"metric_name", "size":16384}`
 
 	thetaSketchJSON, err := json.Marshal(thetaSketch)
 	assert.Nil(t, err)

--- a/builder/dimension/list_filtered.go
+++ b/builder/dimension/list_filtered.go
@@ -11,7 +11,7 @@ type ListFiltered struct {
 	Base
 	Delegate    builder.Dimension `json:"delegate,omitempty"`
 	Values      []string          `json:"values,omitempty"`
-	IsWhiteList bool              `json:"isWhiteList,omitempty"`
+	IsWhiteList *bool             `json:"isWhiteList,omitempty"`
 }
 
 func NewListFiltered() *ListFiltered {
@@ -46,7 +46,7 @@ func (l *ListFiltered) SetValues(values []string) *ListFiltered {
 }
 
 func (l *ListFiltered) SetIsWhiteList(isWhiteList bool) *ListFiltered {
-	l.IsWhiteList = isWhiteList
+	l.IsWhiteList = &isWhiteList
 	return l
 }
 
@@ -55,7 +55,7 @@ func (l *ListFiltered) UnmarshalJSON(data []byte) error {
 		Base
 		Delegate    json.RawMessage `json:"delegate,omitempty"`
 		Values      []string        `json:"values,omitempty"`
-		IsWhiteList bool            `json:"isWhiteList,omitempty"`
+		IsWhiteList *bool           `json:"isWhiteList,omitempty"`
 	}
 	if err := json.Unmarshal(data, &tmp); err != nil {
 		return err

--- a/builder/dimension/lookup.go
+++ b/builder/dimension/lookup.go
@@ -11,9 +11,9 @@ type Lookup struct {
 	Base
 	Name                    string                  `json:"name,omitempty"`
 	ReplaceMissingValueWith string                  `json:"replaceMissingValueWith,omitempty"`
-	RetainMissingValue      bool                    `json:"retainMissingValue,omitempty"`
+	RetainMissingValue      *bool                   `json:"retainMissingValue,omitempty"`
 	Lookup                  builder.LookupExtractor `json:"lookup,omitempty"`
-	Optimize                bool                    `json:"optimize,omitempty"`
+	Optimize                *bool                   `json:"optimize,omitempty"`
 }
 
 type RegisteredLookup struct {
@@ -43,7 +43,7 @@ func (l *Lookup) SetReplaceMissingValueWith(replaceMissingValueWith string) *Loo
 }
 
 func (l *Lookup) SetRetainMissingValue(retainMissingValue bool) *Lookup {
-	l.RetainMissingValue = retainMissingValue
+	l.RetainMissingValue = &retainMissingValue
 	return l
 }
 
@@ -53,7 +53,7 @@ func (l *Lookup) SetLookup(lookup builder.LookupExtractor) *Lookup {
 }
 
 func (l *Lookup) SetOptimize(optimize bool) *Lookup {
-	l.Optimize = optimize
+	l.Optimize = &optimize
 	return l
 }
 
@@ -62,9 +62,9 @@ func (l *Lookup) UnmarshalJSON(data []byte) error {
 		Base
 		Name                    string          `json:"name,omitempty"`
 		ReplaceMissingValueWith string          `json:"replaceMissingValueWith,omitempty"`
-		RetainMissingValue      bool            `json:"retainMissingValue,omitempty"`
+		RetainMissingValue      *bool           `json:"retainMissingValue,omitempty"`
 		Lookup                  json.RawMessage `json:"lookup,omitempty"`
-		Optimize                bool            `json:"optimize,omitempty"`
+		Optimize                *bool           `json:"optimize,omitempty"`
 	}
 	if err := json.Unmarshal(data, &tmp); err != nil {
 		return err

--- a/builder/extractionfn/javascript.go
+++ b/builder/extractionfn/javascript.go
@@ -3,7 +3,7 @@ package extractionfn
 type Javascript struct {
 	Base
 	Function  string `json:"function,omitempty"`
-	Injective bool   `json:"injective,omitempty"`
+	Injective *bool  `json:"injective,omitempty"`
 }
 
 func NewJavascript() *Javascript {
@@ -18,6 +18,6 @@ func (j *Javascript) SetFunction(function string) *Javascript {
 }
 
 func (j *Javascript) SetInjective(injective bool) *Javascript {
-	j.Injective = injective
+	j.Injective = &injective
 	return j
 }

--- a/builder/extractionfn/lookup.go
+++ b/builder/extractionfn/lookup.go
@@ -10,10 +10,10 @@ import (
 type Lookup struct {
 	Base
 	Lookup                  builder.LookupExtractor `json:"lookup,omitempty"`
-	RetainMissingValue      bool                    `json:"retainMissingValue,omitempty"`
+	RetainMissingValue      *bool                   `json:"retainMissingValue,omitempty"`
 	ReplaceMissingValueWith string                  `json:"replaceMissingValueWith,omitempty"`
-	Injective               bool                    `json:"injective,omitempty"`
-	Optimize                bool                    `json:"optimize,omitempty"`
+	Injective               *bool                   `json:"injective,omitempty"`
+	Optimize                *bool                   `json:"optimize,omitempty"`
 }
 
 func NewLookup() *Lookup {
@@ -28,7 +28,7 @@ func (l *Lookup) SetLookup(lookup builder.LookupExtractor) *Lookup {
 }
 
 func (l *Lookup) SetRetainMissingValue(retainMissingValue bool) *Lookup {
-	l.RetainMissingValue = retainMissingValue
+	l.RetainMissingValue = &retainMissingValue
 	return l
 }
 
@@ -38,22 +38,22 @@ func (l *Lookup) SetReplaceMissingValueWith(replaceMissingValueWith string) *Loo
 }
 
 func (l *Lookup) SetInjective(injective bool) *Lookup {
-	l.Injective = injective
+	l.Injective = &injective
 	return l
 }
 
 func (l *Lookup) SetOptimize(optimize bool) *Lookup {
-	l.Optimize = optimize
+	l.Optimize = &optimize
 	return l
 }
 func (l *Lookup) UnmarshalJSON(data []byte) error {
 	var tmp struct {
 		Base
 		Lookup                  json.RawMessage `json:"lookup,omitempty"`
-		RetainMissingValue      bool            `json:"retainMissingValue,omitempty"`
+		RetainMissingValue      *bool           `json:"retainMissingValue,omitempty"`
 		ReplaceMissingValueWith string          `json:"replaceMissingValueWith,omitempty"`
-		Injective               bool            `json:"injective,omitempty"`
-		Optimize                bool            `json:"optimize,omitempty"`
+		Injective               *bool           `json:"injective,omitempty"`
+		Optimize                *bool           `json:"optimize,omitempty"`
 	}
 	if err := json.Unmarshal(data, &tmp); err != nil {
 		return err

--- a/builder/extractionfn/regex.go
+++ b/builder/extractionfn/regex.go
@@ -4,7 +4,7 @@ type Regex struct {
 	Base
 	Expr                    string `json:"expr,omitempty"`
 	Index                   int64  `json:"index,omitempty"`
-	ReplaceMissingValue     bool   `json:"replaceMissingValue,omitempty"`
+	ReplaceMissingValue     *bool  `json:"replaceMissingValue,omitempty"`
 	ReplaceMissingValueWith string `json:"replaceMissingValueWith,omitempty"`
 }
 
@@ -25,7 +25,7 @@ func (r *Regex) SetIndex(index int64) *Regex {
 }
 
 func (r *Regex) SetReplaceMissingValue(replaceMissingValue bool) *Regex {
-	r.ReplaceMissingValue = replaceMissingValue
+	r.ReplaceMissingValue = &replaceMissingValue
 	return r
 }
 

--- a/builder/extractionfn/registered_lookup.go
+++ b/builder/extractionfn/registered_lookup.go
@@ -5,10 +5,10 @@ package extractionfn
 type RegisteredLookup struct {
 	Base
 	Lookup                  string `json:"lookup,omitempty"`
-	RetainMissingValue      bool   `json:"retainMissingValue,omitempty"`
+	RetainMissingValue      *bool  `json:"retainMissingValue,omitempty"`
 	ReplaceMissingValueWith string `json:"replaceMissingValueWith,omitempty"`
-	Injective               *bool  `json:"injective,omitempty"` // Use *bool to differentiate between missing value and false
-	Optimize                *bool  `json:"optimize,omitempty"`  // Use *bool to differentiate between missing value and false
+	Injective               *bool  `json:"injective,omitempty"`
+	Optimize                *bool  `json:"optimize,omitempty"`
 }
 
 func NewRegisteredLookup() *RegisteredLookup {
@@ -23,7 +23,7 @@ func (l *RegisteredLookup) SetLookup(lookup string) *RegisteredLookup {
 }
 
 func (l *RegisteredLookup) SetRetainMissingValue(retainMissingValue bool) *RegisteredLookup {
-	l.RetainMissingValue = retainMissingValue
+	l.RetainMissingValue = &retainMissingValue
 	return l
 }
 

--- a/builder/extractionfn/time.go
+++ b/builder/extractionfn/time.go
@@ -4,7 +4,7 @@ type Time struct {
 	Base
 	TimeFormat   string `json:"timeFormat,omitempty"`
 	ResultFormat string `json:"resultFormat,omitempty"`
-	Joda         bool   `json:"joda,omitempty"`
+	Joda         *bool  `json:"joda,omitempty"`
 }
 
 func NewTime() *Time {
@@ -24,6 +24,6 @@ func (t *Time) SetResultFormat(resultFormat string) *Time {
 }
 
 func (t *Time) SetJoda(joda bool) *Time {
-	t.Joda = joda
+	t.Joda = &joda
 	return t
 }

--- a/builder/extractionfn/time_format.go
+++ b/builder/extractionfn/time_format.go
@@ -13,7 +13,7 @@ type TimeFormat struct {
 	TimeZone    types.DateTimeZone  `json:"timeZone,omitempty"`
 	Locale      string              `json:"locale,omitempty"`
 	Granularity builder.Granularity `json:"granularity,omitempty"`
-	AsMillis    bool                `json:"asMillis,omitempty"`
+	AsMillis    *bool               `json:"asMillis,omitempty"`
 }
 
 func NewTimeFormat() *TimeFormat {
@@ -43,7 +43,7 @@ func (t *TimeFormat) SetGranularity(granularity builder.Granularity) *TimeFormat
 }
 
 func (t *TimeFormat) SetAsMillis(asMillis bool) *TimeFormat {
-	t.AsMillis = asMillis
+	t.AsMillis = &asMillis
 	return t
 }
 
@@ -54,7 +54,7 @@ func (t *TimeFormat) UnmarshalJSON(data []byte) error {
 		TimeZone    types.DateTimeZone `json:"timeZone,omitempty"`
 		Locale      string             `json:"locale,omitempty"`
 		Granularity json.RawMessage    `json:"granularity,omitempty"`
-		AsMillis    bool               `json:"asMillis,omitempty"`
+		AsMillis    *bool              `json:"asMillis,omitempty"`
 	}
 	if err := json.Unmarshal(data, &tmp); err != nil {
 		return err

--- a/builder/filter/bound.go
+++ b/builder/filter/bound.go
@@ -13,8 +13,8 @@ type Bound struct {
 	Dimension    string                 `json:"dimension,omitempty"`
 	Lower        string                 `json:"lower,omitempty"`
 	Upper        string                 `json:"upper,omitempty"`
-	LowerStrict  bool                   `json:"lowerStrict,omitempty"`
-	UpperStrict  bool                   `json:"upperStrict,omitempty"`
+	LowerStrict  *bool                  `json:"lowerStrict,omitempty"`
+	UpperStrict  *bool                  `json:"upperStrict,omitempty"`
 	ExtractionFn builder.ExtractionFn   `json:"extractionFn,omitempty"`
 	Ordering     types.StringComparator `json:"ordering,omitempty"`
 }
@@ -41,12 +41,12 @@ func (b *Bound) SetUpper(upper string) *Bound {
 }
 
 func (b *Bound) SetLowerStrict(lowerStrict bool) *Bound {
-	b.LowerStrict = lowerStrict
+	b.LowerStrict = &lowerStrict
 	return b
 }
 
 func (b *Bound) SetUpperStrict(upperStrict bool) *Bound {
-	b.UpperStrict = upperStrict
+	b.UpperStrict = &upperStrict
 	return b
 }
 
@@ -67,8 +67,8 @@ func (b *Bound) UnmarshalJSON(data []byte) error {
 		Dimension    string                 `json:"dimension,omitempty"`
 		Lower        string                 `json:"lower,omitempty"`
 		Upper        string                 `json:"upper,omitempty"`
-		LowerStrict  bool                   `json:"lowerStrict,omitempty"`
-		UpperStrict  bool                   `json:"upperStrict,omitempty"`
+		LowerStrict  *bool                  `json:"lowerStrict,omitempty"`
+		UpperStrict  *bool                  `json:"upperStrict,omitempty"`
 		ExtractionFn json.RawMessage        `json:"extractionFn,omitempty"`
 		Ordering     types.StringComparator `json:"ordering,omitempty"`
 	}

--- a/builder/filter/filter_tuning.go
+++ b/builder/filter/filter_tuning.go
@@ -2,7 +2,7 @@ package filter
 
 type FilterTuning struct {
 	Base
-	UseBitmapIndex                 bool  `json:"useBitmapIndex,omitempty"`
+	UseBitmapIndex                 *bool `json:"useBitmapIndex,omitempty"`
 	MinCardinalityToUseBitmapIndex int64 `json:"minCardinalityToUseBitmapIndex,omitempty"`
 	MaxCardinalityToUseBitmapIndex int64 `json:"maxCardinalityToUseBitmapIndex,omitempty"`
 }
@@ -14,7 +14,7 @@ func NewFilterTuning() *FilterTuning {
 }
 
 func (f *FilterTuning) SetUseBitmapIndex(useBitmapIndex bool) *FilterTuning {
-	f.UseBitmapIndex = useBitmapIndex
+	f.UseBitmapIndex = &useBitmapIndex
 	return f
 }
 

--- a/builder/lookup/map.go
+++ b/builder/lookup/map.go
@@ -3,7 +3,7 @@ package lookup
 type Map struct {
 	Base
 	Map        map[string]string `json:"map,omitempty"`
-	IsOneToOne bool              `json:"isOneToOne,omitempty"`
+	IsOneToOne *bool             `json:"isOneToOne,omitempty"`
 }
 
 func NewMap() *Map {
@@ -18,6 +18,6 @@ func (m *Map) SetMap(mp map[string]string) *Map {
 }
 
 func (m *Map) SetIsOneToOne(i bool) *Map {
-	m.IsOneToOne = i
+	m.IsOneToOne = &i
 	return m
 }

--- a/builder/query/scan.go
+++ b/builder/query/scan.go
@@ -28,7 +28,7 @@ type Scan struct {
 	Order          Order                   `json:"order,omitempty"`
 	Filter         builder.Filter          `json:"filter,omitempty"`
 	Columns        []string                `json:"columns,omitempty"`
-	Legacy         bool                    `json:"legacy,omitempty"`
+	Legacy         *bool                   `json:"legacy,omitempty"`
 }
 
 // NewScan returns *builder.Scan which can be used to build a scan query.
@@ -118,7 +118,7 @@ func (s *Scan) SetColumns(columns []string) *Scan {
 
 // SetLegacy sets the `druid.query.scan.legacy` field.
 func (s *Scan) SetLegacy(legacy bool) *Scan {
-	s.Legacy = legacy
+	s.Legacy = &legacy
 	return s
 }
 
@@ -134,7 +134,7 @@ func (s *Scan) UnmarshalJSON(data []byte) error {
 		Order          Order             `json:"order,omitempty"`
 		Filter         json.RawMessage   `json:"filter,omitempty"`
 		Columns        []string          `json:"columns,omitempty"`
-		Legacy         bool              `json:"legacy,omitempty"`
+		Legacy         *bool             `json:"legacy,omitempty"`
 	}
 	if err = json.Unmarshal(data, &tmp); err != nil {
 		return err

--- a/builder/query/segment_metadata.go
+++ b/builder/query/segment_metadata.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"encoding/json"
+
 	"github.com/grafadruid/go-druid/builder"
 	"github.com/grafadruid/go-druid/builder/toinclude"
 )
@@ -22,10 +23,10 @@ const (
 type SegmentMetadata struct {
 	Base
 	ToInclude              builder.ToInclude `json:"toInclude,omitempty"`
-	Merge                  bool              `json:"merge,omitempty"`
+	Merge                  *bool             `json:"merge,omitempty"`
 	AnalysisTypes          []AnalysisType    `json:"analysisTypes,omitempty"`
-	UsingDefaultInterval   bool              `json:"usingDefaultInterval,omitempty"`
-	LenientAggregatorMerge bool              `json:"lenientAggregatorMerge,omitempty"`
+	UsingDefaultInterval   *bool             `json:"usingDefaultInterval,omitempty"`
+	LenientAggregatorMerge *bool             `json:"lenientAggregatorMerge,omitempty"`
 }
 
 func NewSegmentMetadata() *SegmentMetadata {
@@ -55,7 +56,7 @@ func (s *SegmentMetadata) SetToInclude(toInclude builder.ToInclude) *SegmentMeta
 }
 
 func (s *SegmentMetadata) SetMerge(merge bool) *SegmentMetadata {
-	s.Merge = merge
+	s.Merge = &merge
 	return s
 }
 
@@ -65,12 +66,12 @@ func (s *SegmentMetadata) SetAnalysisTypes(analysisTypes []AnalysisType) *Segmen
 }
 
 func (s *SegmentMetadata) SetUsingDefaultInterval(usingDefaultInterval bool) *SegmentMetadata {
-	s.UsingDefaultInterval = usingDefaultInterval
+	s.UsingDefaultInterval = &usingDefaultInterval
 	return s
 }
 
 func (s *SegmentMetadata) SetLenientAggregatorMerge(lenientAggregatorMerge bool) *SegmentMetadata {
-	s.LenientAggregatorMerge = lenientAggregatorMerge
+	s.LenientAggregatorMerge = &lenientAggregatorMerge
 	return s
 }
 
@@ -78,10 +79,10 @@ func (s *SegmentMetadata) UnmarshalJSON(data []byte) error {
 	var err error
 	var tmp struct {
 		ToInclude              json.RawMessage `json:"toInclude,omitempty"`
-		Merge                  bool            `json:"merge,omitempty"`
+		Merge                  *bool           `json:"merge,omitempty"`
 		AnalysisTypes          []AnalysisType  `json:"analysisTypes,omitempty"`
-		UsingDefaultInterval   bool            `json:"usingDefaultInterval,omitempty"`
-		LenientAggregatorMerge bool            `json:"lenientAggregatorMerge,omitempty"`
+		UsingDefaultInterval   *bool           `json:"usingDefaultInterval,omitempty"`
+		LenientAggregatorMerge *bool           `json:"lenientAggregatorMerge,omitempty"`
 	}
 	if err = json.Unmarshal(data, &tmp); err != nil {
 		return err

--- a/builder/query/sql.go
+++ b/builder/query/sql.go
@@ -8,7 +8,7 @@ type SQL struct {
 	Base
 	Query        string         `json:"query,omitempty"`
 	ResultFormat string         `json:"resultFormat,omitempty"`
-	Header       bool           `json:"header,omitempty"`
+	Header       *bool          `json:"header,omitempty"`
 	Parameters   []SQLParameter `json:"parameters,omitempty"`
 }
 
@@ -39,7 +39,7 @@ func (s *SQL) SetResultFormat(resultFormat string) *SQL {
 }
 
 func (s *SQL) SetHeader(header bool) *SQL {
-	s.Header = header
+	s.Header = &header
 	return s
 }
 
@@ -53,7 +53,7 @@ func (s *SQL) UnmarshalJSON(data []byte) error {
 	var tmp struct {
 		Query        string         `json:"query,omitempty"`
 		ResultFormat string         `json:"resultFormat,omitempty"`
-		Header       bool           `json:"header,omitempty"`
+		Header       *bool          `json:"header,omitempty"`
 		Parameters   []SQLParameter `json:"parameters,omitempty"`
 	}
 	if err := json.Unmarshal(data, &tmp); err != nil {

--- a/builder/query/timeseries.go
+++ b/builder/query/timeseries.go
@@ -3,6 +3,7 @@ package query
 import (
 	"encoding/json"
 	"errors"
+
 	"github.com/grafadruid/go-druid/builder"
 	"github.com/grafadruid/go-druid/builder/aggregation"
 	"github.com/grafadruid/go-druid/builder/filter"
@@ -13,7 +14,7 @@ import (
 
 type Timeseries struct {
 	Base
-	Descending       bool                     `json:"descending,omitempty"`
+	Descending       *bool                    `json:"descending,omitempty"`
 	VirtualColumns   []builder.VirtualColumn  `json:"virtualColumns,omitempty"`
 	Filter           builder.Filter           `json:"filter,omitempty"`
 	Granularity      builder.Granularity      `json:"granularity,omitempty"`
@@ -44,7 +45,7 @@ func (t *Timeseries) SetContext(context map[string]interface{}) *Timeseries {
 }
 
 func (t *Timeseries) SetDescending(descending bool) *Timeseries {
-	t.Descending = descending
+	t.Descending = &descending
 	return t
 }
 
@@ -81,7 +82,7 @@ func (t *Timeseries) SetLimit(limit int64) *Timeseries {
 func (t *Timeseries) UnmarshalJSON(data []byte) error {
 	var err error
 	var tmp struct {
-		Descending       bool              `json:"descending,omitempty"`
+		Descending       *bool             `json:"descending,omitempty"`
 		VirtualColumns   []json.RawMessage `json:"virtualColumns,omitempty"`
 		Filter           json.RawMessage   `json:"filter,omitempty"`
 		Granularity      json.RawMessage   `json:"granularity,omitempty"`

--- a/builder/searchqueryspec/contains.go
+++ b/builder/searchqueryspec/contains.go
@@ -3,7 +3,7 @@ package searchqueryspec
 type Contains struct {
 	Base
 	Value         string `json:"value,omitempty"`
-	CaseSensitive bool   `json:"caseSensitive,omitempty"`
+	CaseSensitive *bool  `json:"caseSensitive,omitempty"`
 }
 
 func NewContains() *Contains {
@@ -18,6 +18,6 @@ func (c *Contains) SetValue(value string) *Contains {
 }
 
 func (c *Contains) SetCaseSensitive(caseSensitive bool) *Contains {
-	c.CaseSensitive = caseSensitive
+	c.CaseSensitive = &caseSensitive
 	return c
 }

--- a/builder/searchqueryspec/fragment.go
+++ b/builder/searchqueryspec/fragment.go
@@ -3,7 +3,7 @@ package searchqueryspec
 type Fragment struct {
 	Base
 	Value         string `json:"value,omitempty"`
-	CaseSensitive bool   `json:"caseSensitive,omitempty"`
+	CaseSensitive *bool  `json:"caseSensitive,omitempty"`
 }
 
 func NewFragment() *Fragment {
@@ -18,6 +18,6 @@ func (f *Fragment) SetValue(value string) *Fragment {
 }
 
 func (f *Fragment) SetCaseSensitive(caseSensitive bool) *Fragment {
-	f.CaseSensitive = caseSensitive
+	f.CaseSensitive = &caseSensitive
 	return f
 }


### PR DESCRIPTION
Boolean fields used for building JSON were changed from  `bool` to `*bool`. The reason is that if `bool` fields the following happens:
- if the `omitempty` tag is present, setting a field to `false` means it won't be included in the output JSON.
- conversely, if `omitempty` is not present, not setting a field means it _will_ be included as `false` in the output JSON.

In many cases, Druid behaves differently depending if a boolean field is set to true, false, or not set, so it's important to distinguish the three cases.