### PR TITLE
Allow dimension and datasource values to be string

### DIFF
--- a/builder/datasource/data_source.go
+++ b/builder/datasource/data_source.go
@@ -29,7 +29,15 @@ func Load(data []byte) (builder.DataSource, error) {
 		Typ builder.ComponentType `json:"type,omitempty"`
 	}
 	if err := json.Unmarshal(data, &t); err != nil {
-		return nil, err
+		// the datasource may be a string which is supported by Druid
+		var tstr string
+		if err := json.Unmarshal(data, &tstr); err != nil {
+			return nil, err
+		}
+		// We will just make it table which is the most common type according to the Druid docs
+		d = NewTable()
+		d.(*Table).SetName(tstr)
+		return d, nil
 	}
 	switch t.Typ {
 	case "globalTable":

--- a/builder/dimension/dimension.go
+++ b/builder/dimension/dimension.go
@@ -48,8 +48,20 @@ func Load(data []byte) (builder.Dimension, error) {
 		Typ builder.ComponentType `json:"type,omitempty"`
 	}
 	if err := json.Unmarshal(data, &t); err != nil {
-		return nil, err
+		// the dimension may be a string which is supported by Druid
+		var tstr string
+		if err := json.Unmarshal(data, &tstr); err != nil {
+			return nil, err
+		}
+		// We will just make it a 'default' dimension
+		d = &Base{}
+		d.(*Base).SetType("Default")
+		d.(*Base).SetDimension(tstr)
+		d.(*Base).SetOutputName(tstr)
+		d.(*Base).SetOutputType(types.String)
+		return d, nil
 	}
+
 	switch t.Typ {
 	case "default":
 		d = NewDefault()

--- a/builder/intervals/intervals.go
+++ b/builder/intervals/intervals.go
@@ -2,7 +2,6 @@ package intervals
 
 import (
 	"encoding/json"
-	"errors"
 
 	"github.com/grafadruid/go-druid/builder"
 )
@@ -25,17 +24,19 @@ func Load(data []byte) (builder.Intervals, error) {
 	if string(data) == "null" {
 		return i, nil
 	}
-	var t struct {
-		Typ builder.ComponentType `json:"type,omitempty"`
-	}
-	if err := json.Unmarshal(data, &t); err != nil {
+	// "intervals" in the spec is just an string array
+	var intv []string
+	if err := json.Unmarshal(data, &intv); err != nil {
 		return nil, err
 	}
-	switch t.Typ {
-	case "intervals":
-		i = NewIntervals()
-	default:
-		return nil, errors.New("unsupported intervals type")
+	// Now cast the only array item into an actual "interval"
+	interval := Interval(intv[0])
+	// create our "intervals" object with "Typ"
+	i = &Intervals{
+		Base: Base{
+			Typ: "intervals",
+		},
+		Intervals: []*Interval{&interval},
 	}
-	return i, json.Unmarshal(data, &i)
+	return i, nil
 }


### PR DESCRIPTION
### Dimension and datasource
While I was playing around with this plugin, I noticed that I was getting JSON unmarshal errors for what should be valid JSON queries.

After digging around I found that this schema validation code only accepts [DimensionSpec](https://druid.apache.org/docs/latest/querying/dimensionspecs.html) and [Datasource spec](https://druid.apache.org/docs/latest/querying/datasource.html) objects.
But the query language accepted by Druid does allow plain strings to be used.

I've put some extra validation in which creates the objects manually if plain string values are found

### Intervals
A similar thing happened for parsing Intervals.
The parsing code in `intervals.go` appeared to be expecting a full JSON object:
```
{"intervals": ["2022-01-10T00:00:00.000/2022-01-20T00:00:00.000"]}
```

But the code that was calling `intervals.go:Load()` was only passing the value. Which caused the unmarshal to fail.



Let me know if this looks okay to you, or if there's anything you want to change.