### PR TITLE
Pass HTTP headers

### DIFF
--- a/query.go
+++ b/query.go
@@ -16,7 +16,7 @@ type QueryService struct {
 	client *Client
 }
 
-func (q *QueryService) Execute(qry builder.Query, result interface{}, headers http.Header) (*Response, error) {
+func (q *QueryService) Execute(qry builder.Query, result interface{}, headers ...http.Header) (*Response, error) {
 	var path string
 	switch qry.Type() {
 	case "sql":
@@ -28,9 +28,11 @@ func (q *QueryService) Execute(qry builder.Query, result interface{}, headers ht
 	if err != nil {
 		return nil, err
 	}
-	for k, v := range headers {
-		for _, vv := range v {
-			r.Header.Set(k, vv)
+	if len(headers) >= 1 {
+		for k, v := range headers[0] {
+			for _, vv := range v {
+				r.Header.Set(k, vv)
+			}
 		}
 	}
 	resp, err := q.client.Do(r, result)

--- a/query.go
+++ b/query.go
@@ -1,6 +1,8 @@
 package druid
 
 import (
+	"net/http"
+
 	"github.com/grafadruid/go-druid/builder"
 	"github.com/grafadruid/go-druid/builder/query"
 )
@@ -14,7 +16,7 @@ type QueryService struct {
 	client *Client
 }
 
-func (q *QueryService) Execute(qry builder.Query, result interface{}) (*Response, error) {
+func (q *QueryService) Execute(qry builder.Query, result interface{}, headers http.Header) (*Response, error) {
 	var path string
 	switch qry.Type() {
 	case "sql":
@@ -25,6 +27,11 @@ func (q *QueryService) Execute(qry builder.Query, result interface{}) (*Response
 	r, err := q.client.NewRequest("POST", path, qry)
 	if err != nil {
 		return nil, err
+	}
+	for k, v := range headers {
+		for _, vv := range v {
+			r.Header.Set(k, vv)
+		}
 	}
 	resp, err := q.client.Do(r, result)
 	if err != nil {


### PR DESCRIPTION
I needed to pass custom HTTP headers for authentication, which required this change. For backward compatibility it could be a separate method named `ExecuteWithHeaders`.