### PR TITLE
Improvements/add testcode modify cadinality

### DIFF
--- a/builder/aggregation/cardinality.go
+++ b/builder/aggregation/cardinality.go
@@ -1,12 +1,14 @@
 package aggregation
 
+import "github.com/grafadruid/go-druid/builder"
+
 // Cardinality Each individual element of the "fields" list can be a String or DimensionSpec.
 // A String dimension in the fields list is equivalent to a DefaultDimensionSpec (no transformations).
 type Cardinality struct {
 	Base
-	Fields []interface{} `json:"fields,omitempty"`
-	ByRow  *bool         `json:"byRow,omitempty"`
-	Round  *bool         `json:"round,omitempty"`
+	Fields []builder.DimensionSpec `json:"fields,omitempty"`
+	ByRow  *bool                   `json:"byRow,omitempty"`
+	Round  *bool                   `json:"round,omitempty"`
 }
 
 func NewCardinality() *Cardinality {
@@ -20,7 +22,7 @@ func (c *Cardinality) SetName(name string) *Cardinality {
 	return c
 }
 
-func (c *Cardinality) SetFields(fields []interface{}) *Cardinality {
+func (c *Cardinality) SetFields(fields []builder.DimensionSpec) *Cardinality {
 	c.Fields = fields
 	return c
 }

--- a/builder/aggregation/cardinality.go
+++ b/builder/aggregation/cardinality.go
@@ -1,10 +1,12 @@
 package aggregation
 
+// Cardinality Each individual element of the "fields" list can be a String or DimensionSpec.
+// A String dimension in the fields list is equivalent to a DefaultDimensionSpec (no transformations).
 type Cardinality struct {
 	Base
-	Fields []string `json:"fields,omitempty"`
-	ByRow  *bool    `json:"byRow,omitempty"`
-	Round  *bool    `json:"round,omitempty"`
+	Fields []interface{} `json:"fields,omitempty"`
+	ByRow  *bool         `json:"byRow,omitempty"`
+	Round  *bool         `json:"round,omitempty"`
 }
 
 func NewCardinality() *Cardinality {
@@ -18,7 +20,7 @@ func (c *Cardinality) SetName(name string) *Cardinality {
 	return c
 }
 
-func (c *Cardinality) SetFields(fields []string) *Cardinality {
+func (c *Cardinality) SetFields(fields []interface{}) *Cardinality {
 	c.Fields = fields
 	return c
 }

--- a/builder/aggregation/cardinality_test.go
+++ b/builder/aggregation/cardinality_test.go
@@ -1,0 +1,37 @@
+package aggregation
+
+import (
+	"encoding/json"
+	"github.com/grafadruid/go-druid/builder/dimension"
+	"github.com/grafadruid/go-druid/builder/extractionfn"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCardinality(t *testing.T) {
+	cardinality := NewCardinality()
+	substringExtra := extractionfn.NewSubstring().SetIndex(0).SetLength(1)
+	extraction := dimension.NewExtraction().SetDimension("last_name").
+		SetOutputName("last_name_first_char").
+		SetExtractionFn(substringExtra)
+
+	cardinality.SetName("distinct_last_name_first_char").
+		SetFields([]interface{}{extraction}).SetByRow(true).SetRound(false)
+	expected := `{
+  "type": "cardinality",
+  "name": "distinct_last_name_first_char",
+  "fields": [
+    {
+     "type" : "extraction",
+     "dimension" : "last_name",
+     "outputName" :  "last_name_first_char",
+     "extractionFn" : { "type" : "substring", "index" : 0, "length" : 1 }
+    }
+  ],
+  "byRow" : true,
+  "round" : false
+}`
+	cardinalityJSON, err := json.Marshal(cardinality)
+	assert.Nil(t, err)
+	assert.JSONEq(t, expected, string(cardinalityJSON))
+}

--- a/builder/aggregation/cardinality_test.go
+++ b/builder/aggregation/cardinality_test.go
@@ -2,6 +2,7 @@ package aggregation
 
 import (
 	"encoding/json"
+	"github.com/grafadruid/go-druid/builder"
 	"github.com/grafadruid/go-druid/builder/dimension"
 	"github.com/grafadruid/go-druid/builder/extractionfn"
 	"github.com/stretchr/testify/assert"
@@ -16,7 +17,7 @@ func TestCardinality(t *testing.T) {
 		SetExtractionFn(substringExtra)
 
 	cardinality.SetName("distinct_last_name_first_char").
-		SetFields([]interface{}{extraction}).SetByRow(true).SetRound(false)
+		SetFields([]builder.DimensionSpec{extraction}).SetByRow(true).SetRound(false)
 	expected := `{
   "type": "cardinality",
   "name": "distinct_last_name_first_char",

--- a/builder/aggregation/javascript_test.go
+++ b/builder/aggregation/javascript_test.go
@@ -1,0 +1,27 @@
+package aggregation
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestJavascript(t *testing.T) {
+	javaScript := NewJavascript()
+	javaScript.SetName("sum(log(x)*y) + 10").
+		SetFieldNames([]string{"x", "y"}).
+		SetFnAggregate("function(current, a, b)      { return current + (Math.log(a) * b); }").
+		SetFnCombine("function(partialA, partialB) { return partialA + partialB; }").
+		SetFnReset("function()                   { return 10; }")
+	expected := `{
+  "type": "javascript",
+  "name": "sum(log(x)*y) + 10",
+  "fieldNames": ["x", "y"],
+  "fnAggregate" : "function(current, a, b)      { return current + (Math.log(a) * b); }",
+  "fnCombine"   : "function(partialA, partialB) { return partialA + partialB; }",
+  "fnReset"     : "function()                   { return 10; }"
+}`
+	javaScriptJSON, err := json.Marshal(javaScript)
+	assert.Nil(t, err)
+	assert.JSONEq(t, expected, string(javaScriptJSON))
+}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -1,5 +1,7 @@
 package builder
 
+import "github.com/grafadruid/go-druid/builder/types"
+
 type ComponentType = string
 
 type Query interface {
@@ -20,6 +22,18 @@ type DataSource interface {
 
 type Dimension interface {
 	Type() ComponentType
+}
+
+type DimensionSpec interface {
+	Dimension
+	GetDimension() string
+	GetOutputName() string
+	GetOutputType() types.OutputType
+	GetExtractionFn() ExtractionFn // Deprecated
+}
+
+type BaseFilteredDimensionSpec interface {
+	DimensionSpec
 }
 
 type ExtractionFn interface {

--- a/builder/dimension/default.go
+++ b/builder/dimension/default.go
@@ -1,9 +1,28 @@
 package dimension
 
-import "github.com/grafadruid/go-druid/builder/types"
+import (
+	"github.com/grafadruid/go-druid/builder"
+	"github.com/grafadruid/go-druid/builder/types"
+)
 
 type Default struct {
 	Base
+}
+
+func (d *Default) GetDimension() string {
+	return d.Base.Dimension
+}
+
+func (d *Default) GetOutputName() string {
+	return d.Base.OutputName
+}
+
+func (d *Default) GetOutputType() types.OutputType {
+	return d.Base.OutputType
+}
+
+func (d *Default) GetExtractionFn() builder.ExtractionFn {
+	return nil
 }
 
 func NewDefault() *Default {

--- a/builder/dimension/dimension.go
+++ b/builder/dimension/dimension.go
@@ -39,8 +39,8 @@ func (b *Base) Type() builder.ComponentType {
 	return b.Typ
 }
 
-func Load(data []byte) (builder.Dimension, error) {
-	var d builder.Dimension
+func Load(data []byte) (builder.DimensionSpec, error) {
+	var d builder.DimensionSpec
 	if string(data) == "null" {
 		return d, nil
 	}

--- a/builder/dimension/extraction.go
+++ b/builder/dimension/extraction.go
@@ -12,6 +12,22 @@ type Extraction struct {
 	ExtractionFn builder.ExtractionFn `json:"extractionFn,omitempty"`
 }
 
+func (e *Extraction) GetDimension() string {
+	return e.Base.Dimension
+}
+
+func (e *Extraction) GetOutputName() string {
+	return e.Base.OutputName
+}
+
+func (e *Extraction) GetOutputType() types.OutputType {
+	return e.Base.OutputType
+}
+
+func (e *Extraction) GetExtractionFn() builder.ExtractionFn {
+	return e.ExtractionFn
+}
+
 func NewExtraction() *Extraction {
 	e := &Extraction{}
 	e.SetType("extraction")

--- a/builder/dimension/extraction_test.go
+++ b/builder/dimension/extraction_test.go
@@ -1,0 +1,29 @@
+package dimension
+
+import (
+	"encoding/json"
+	"github.com/grafadruid/go-druid/builder/extractionfn"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewExtraction(t *testing.T) {
+	substringExtra := extractionfn.NewSubstring().SetIndex(0).SetLength(1)
+	extraction := NewExtraction().SetDimension("last_name").
+		SetOutputName("last_name_first_char").
+		SetExtractionFn(substringExtra)
+	expected := `{
+  "type": "extraction",
+  "dimension": "last_name",
+  "outputName": "last_name_first_char",
+  "extractionFn": {
+    "type": "substring",
+    "index": 0,
+    "length": 1
+  }
+}`
+	extractionJSON, err := json.Marshal(extraction)
+	assert.Nil(t, err)
+	assert.JSONEq(t, expected, string(extractionJSON))
+
+}

--- a/builder/dimension/list_filtered.go
+++ b/builder/dimension/list_filtered.go
@@ -14,6 +14,22 @@ type ListFiltered struct {
 	IsWhiteList *bool             `json:"isWhiteList,omitempty"`
 }
 
+func (l *ListFiltered) GetDimension() string {
+	return l.Base.Dimension
+}
+
+func (l *ListFiltered) GetOutputName() string {
+	return l.Base.OutputName
+}
+
+func (l *ListFiltered) GetOutputType() types.OutputType {
+	return l.Base.OutputType
+}
+
+func (l *ListFiltered) GetExtractionFn() builder.ExtractionFn {
+	return nil
+}
+
 func NewListFiltered() *ListFiltered {
 	l := &ListFiltered{}
 	l.SetType("listFiltered")

--- a/builder/dimension/lookup.go
+++ b/builder/dimension/lookup.go
@@ -37,6 +37,11 @@ func (l *Lookup) SetOutputName(outputName string) *Lookup {
 	return l
 }
 
+func (l *Lookup) SetDimension(dimensionName string) *Lookup {
+	l.Base.SetDimension(dimensionName)
+	return l
+}
+
 func (l *Lookup) SetReplaceMissingValueWith(replaceMissingValueWith string) *Lookup {
 	l.ReplaceMissingValueWith = replaceMissingValueWith
 	return l

--- a/builder/dimension/lookup.go
+++ b/builder/dimension/lookup.go
@@ -2,6 +2,7 @@ package dimension
 
 import (
 	"encoding/json"
+	"github.com/grafadruid/go-druid/builder/types"
 
 	"github.com/grafadruid/go-druid/builder"
 	"github.com/grafadruid/go-druid/builder/lookup"
@@ -14,6 +15,22 @@ type Lookup struct {
 	RetainMissingValue      *bool                   `json:"retainMissingValue,omitempty"`
 	Lookup                  builder.LookupExtractor `json:"lookup,omitempty"`
 	Optimize                *bool                   `json:"optimize,omitempty"`
+}
+
+func (l *Lookup) GetDimension() string {
+	return l.Base.Dimension
+}
+
+func (l *Lookup) GetOutputName() string {
+	return l.Base.OutputName
+}
+
+func (l *Lookup) GetOutputType() types.OutputType {
+	return l.Base.OutputType
+}
+
+func (l *Lookup) GetExtractionFn() builder.ExtractionFn {
+	return nil
 }
 
 type RegisteredLookup struct {
@@ -37,8 +54,8 @@ func (l *Lookup) SetOutputName(outputName string) *Lookup {
 	return l
 }
 
-func (l *Lookup) SetDimension(dimensionName string) *Lookup {
-	l.Base.SetDimension(dimensionName)
+func (l *Lookup) SetDimension(dimension string) *Lookup {
+	l.Base.SetDimension(dimension)
 	return l
 }
 

--- a/builder/dimension/lookup_test.go
+++ b/builder/dimension/lookup_test.go
@@ -2,6 +2,7 @@ package dimension
 
 import (
 	"encoding/json"
+	lookup2 "github.com/grafadruid/go-druid/builder/lookup"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,6 +13,25 @@ func TestDimensionLookup(t *testing.T) {
 
 	// "omitempty" will ignore boolean=false
 	expected := `{"name":"lookup_name", "outputName":"output_name", "retainMissingValue":true, "type":"lookup"}`
+
+	lookupJSON, err := json.Marshal(lookup)
+	assert.Nil(t, err)
+	assert.JSONEq(t, expected, string(lookupJSON))
+}
+
+func TestNewLookup(t *testing.T) {
+	expected := `{
+	 "type":"lookup",
+	 "dimension":"dimensionName",
+	 "outputName":"dimensionOutputName",
+	 "replaceMissingValueWith":"missing_value",
+	 "retainMissingValue":false,
+	 "lookup":{"type": "map", "map":{"key":"value"}, "isOneToOne":false}
+	}`
+	mapFn := lookup2.NewMap().SetMap(map[string]string{"key": "value"}).SetIsOneToOne(false)
+	lookup := NewLookup().SetOutputName("dimensionOutputName").SetRetainMissingValue(false).
+		SetDimension("dimensionName").
+		SetReplaceMissingValueWith("missing_value").SetLookup(mapFn)
 
 	lookupJSON, err := json.Marshal(lookup)
 	assert.Nil(t, err)

--- a/builder/dimension/prefix_filtered.go
+++ b/builder/dimension/prefix_filtered.go
@@ -13,6 +13,22 @@ type PrefixFiltered struct {
 	Prefix   string            `json:"prefix,omitempty"`
 }
 
+func (p *PrefixFiltered) GetDimension() string {
+	return p.Base.Dimension
+}
+
+func (p *PrefixFiltered) GetOutputName() string {
+	return p.Base.OutputName
+}
+
+func (p *PrefixFiltered) GetOutputType() types.OutputType {
+	return p.Base.OutputType
+}
+
+func (p *PrefixFiltered) GetExtractionFn() builder.ExtractionFn {
+	return nil
+}
+
 func NewPrefixFiltered() *PrefixFiltered {
 	p := &PrefixFiltered{}
 	p.SetType("prefixFiltered")

--- a/builder/dimension/regex_filtered.go
+++ b/builder/dimension/regex_filtered.go
@@ -13,6 +13,22 @@ type RegexFiltered struct {
 	Pattern  string            `json:"pattern,omitempty"`
 }
 
+func (r *RegexFiltered) GetDimension() string {
+	return r.Base.Dimension
+}
+
+func (r *RegexFiltered) GetOutputName() string {
+	return r.Base.OutputName
+}
+
+func (r *RegexFiltered) GetOutputType() types.OutputType {
+	return r.Base.OutputType
+}
+
+func (r *RegexFiltered) GetExtractionFn() builder.ExtractionFn {
+	return nil
+}
+
 func NewRegexFiltered() *RegexFiltered {
 	r := &RegexFiltered{}
 	r.SetType("regexFiltered")

--- a/builder/extractionfn/substring.go
+++ b/builder/extractionfn/substring.go
@@ -2,7 +2,7 @@ package extractionfn
 
 type Substring struct {
 	Base
-	Index  int64 `json:"index,omitempty"`
+	Index  int64 `json:"index"` // If omitempty is present, it disappears from json when index is 0
 	Length int64 `json:"length,omitempty"`
 }
 


### PR DESCRIPTION
Hello, I modified some code and added test code. #31 


1. Changed the type of cardinality's fieid([]string -> []interface{}). According to the documentation
`Each individual element of the "fields" list can be a String or DimensionSpec`

2. Remove omitempty of index of substring - If omitempty is present, it disappears from json when index is 0

3. add SetDimension method of lookup - I wrote a test code with the example code in the official documentation, but it didn't work properly, so I modified it.

Additionally, I wrote test codes for cardinality, extraction, javascript, and lookup.
