### PR TITLE
Add subquery test code

### DIFF
--- a/builder/datasource/query.go
+++ b/builder/datasource/query.go
@@ -8,7 +8,7 @@ import (
 
 type Query struct {
 	Base
-	Query builder.Query `json:"-,omitempty"`
+	Query builder.Query `json:"query,omitempty"`
 }
 
 func NewQuery() *Query {
@@ -17,8 +17,9 @@ func NewQuery() *Query {
 	return q
 }
 
-func (q *Query) SetQuery(qry builder.Query) {
+func (q *Query) SetQuery(qry builder.Query) *Query {
 	q.Query = qry
+	return q
 }
 
 func (q *Query) UnmarshalJSONWithQueryLoader(data []byte, loader func(data []byte) (builder.Query, error)) error {

--- a/builder/datasource/query.go
+++ b/builder/datasource/query.go
@@ -2,7 +2,6 @@ package datasource
 
 import (
 	"encoding/json"
-
 	"github.com/grafadruid/go-druid/builder"
 )
 

--- a/builder/extractionfn/lower.go
+++ b/builder/extractionfn/lower.go
@@ -2,7 +2,7 @@ package extractionfn
 
 type Lower struct {
 	Base
-	Locale string `json:"locale,omitempty"`
+	Locale string `json:"locale"`
 }
 
 func NewLower() *Lower {

--- a/builder/extractionfn/lower.go
+++ b/builder/extractionfn/lower.go
@@ -2,7 +2,7 @@ package extractionfn
 
 type Lower struct {
 	Base
-	Locale string `json:"locale"`
+	Locale string `json:"locale,omitempty"`
 }
 
 func NewLower() *Lower {

--- a/builder/query/query.go
+++ b/builder/query/query.go
@@ -59,11 +59,11 @@ func (b *Base) UnmarshalJSON(data []byte) error {
 	}
 	if b.Type() != "sql" {
 		d, err := datasource.Load(tmp.DataSource)
+		if err != nil && d.Type() == "query" {
+			err = d.(*datasource.Query).UnmarshalJSONWithQueryLoader(tmp.DataSource, Load) // cycle import
+		}
 		if err != nil {
 			return err
-		}
-		if d.Type() == "query" {
-			d.(*datasource.Query).UnmarshalJSONWithQueryLoader(tmp.DataSource, Load)
 		}
 		b.DataSource = d
 		var i builder.Intervals

--- a/builder/query/query_test.go
+++ b/builder/query/query_test.go
@@ -81,3 +81,25 @@ func TestAllSetterSQL(t *testing.T) {
 	assert.JSONEq(t, expected, string(expressionJSON))
 
 }
+
+func TestScanUnmarshalJson(t *testing.T) {
+	expected := `{
+    "queryType": "scan",
+    "dataSource": {
+      "type": "table",
+      "name": "A"
+    },
+    "columns": [
+      "AT"
+    ],
+    "intervals": {
+      "type": "intervals",
+      "intervals": [
+        "1980-06-12T22:30:00.000Z/2020-01-26T23:00:00.000Z"
+      ]
+    }
+  }`
+	scan := NewScan()
+	err := scan.UnmarshalJSON([]byte(expected))
+	assert.Nil(t, err)
+}

--- a/examples/fromjson/main.go
+++ b/examples/fromjson/main.go
@@ -1,3 +1,6 @@
+//go:build mage
+// +build mage
+
 package main
 
 import (

--- a/examples/fromjson/main.go
+++ b/examples/fromjson/main.go
@@ -1,6 +1,3 @@
-//go:build mage
-// +build mage
-
 package main
 
 import (

--- a/examples/fromjson/main.go
+++ b/examples/fromjson/main.go
@@ -1,15 +1,12 @@
-//go:build mage
-// +build mage
-
 package main
 
 import (
 	"fmt"
+	"github.com/grafadruid/go-druid"
+	"github.com/grafadruid/go-druid/builder"
 	"log"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/grafadruid/go-druid"
-	"github.com/grafadruid/go-druid/builder"
 )
 
 func loadAndExecute(d *druid.Client, qry []byte) {
@@ -54,8 +51,8 @@ func main() {
 	loadAndExecute(d, []byte(qry))
 
 	// https://github.com/grafadruid/go-druid/issues/15
-	qry = `{"batchSize":20480,"columns":["__time","channel","cityName","comment","count","countryIsoCode","diffUrl","flags","isAnonymous","isMinor","isNew","isRobot","isUnpatrolled","metroCode","namespace","page","regionIsoCode","regionName","sum_added","sum_commentLength","sum_deleted","sum_delta","sum_deltaBucket","user"],"dataSource":{"type":"query","query":{"queryType":"scan","dataSource":{"type":"table","name":"A"},"columns":["AT"],"intervals":{"type":"intervals","intervals":["1980-06-12T22:30:00.000Z/2020-01-26T23:00:00.000Z"]}}},"filter":{"dimension":"countryName","extractionFn":{"locale":"","type":"lower"},"type":"selector","value":"france"},"intervals":{"type":"intervals","intervals":["1980-06-12T22:30:00.000Z/2020-01-26T23:00:00.000Z"]},"limit":10,"order":"descending","queryType":"scan"}`
-	//loadAndExecute(d, []byte(qry))
+	qry = `{"batchSize":20480,"columns":["__time","channel","cityName","comment","count","countryIsoCode","diffUrl","flags","isAnonymous","isMinor","isNew","isRobot","isUnpatrolled","metroCode","namespace","page","regionIsoCode","regionName","sum_added","sum_commentLength","sum_deleted","sum_delta","sum_deltaBucket","user"],"dataSource":{"type":"query","query":{"queryType":"scan","dataSource":{"type":"table","name":"A"},"columns":["AT"],"intervals":{"type":"intervals","intervals":["1980-06-12T22:30:00.000Z/2020-01-26T23:00:00.000Z"]}}},"filter":{"dimension":"countryName","extractionFn":{"locale":"","type":"lower"},"type":"selector","value":"france"},"intervals":{"type":"intervals","intervals":["1980-06-12T22:30:00.000Z/2020-01-26T23:00:00.000Z"]},"limit":10,"order":"none","queryType":"scan"}`
+	loadAndExecute(d, []byte(qry))
 
 	qry = `{"context":{"con":"text"},"query":"SELECT * \nFROM \"wikipedia\"\nWHERE \"countryName\" = 'France'\nLIMIT 10","queryType":"sql", "resultFormat":"array", "header": true}`
 	loadAndExecute(d, []byte(qry))

--- a/examples/subqueryExample.go
+++ b/examples/subqueryExample.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"github.com/davecgh/go-spew/spew"
+	"github.com/grafadruid/go-druid"
+	"github.com/grafadruid/go-druid/builder"
+	"github.com/grafadruid/go-druid/builder/aggregation"
+	datasource2 "github.com/grafadruid/go-druid/builder/datasource"
+	"github.com/grafadruid/go-druid/builder/dimension"
+	"github.com/grafadruid/go-druid/builder/extractionfn"
+	"github.com/grafadruid/go-druid/builder/filter"
+	"github.com/grafadruid/go-druid/builder/granularity"
+	"github.com/grafadruid/go-druid/builder/intervals"
+	"github.com/grafadruid/go-druid/builder/query"
+	"github.com/grafadruid/go-druid/builder/topnmetric"
+	"log"
+	"time"
+)
+
+func main() {
+
+	d, err := druid.NewClient("http://localhost:8888")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var results []map[string]interface{}
+
+	_, err = d.Query().Execute(MakeScanSubQuery(), &results)
+	if err != nil {
+		log.Fatal(err)
+	}
+	spew.Dump(results)
+
+	_, err = d.Query().Execute(MakeTimeSeriesSubQuery(), &results)
+	if err != nil {
+		log.Fatal(err)
+	}
+	spew.Dump(results)
+
+}
+
+// MakeScanSubQuery Result is nil
+func MakeScanSubQuery() *query.Scan {
+	location, _ := time.LoadLocation("UTC")
+
+	start, _ := time.ParseInLocation(time.RFC3339Nano,
+		"1980-06-12T22:30:00.000Z",
+		location)
+	end, _ := time.ParseInLocation(time.RFC3339Nano,
+		"2023-01-26T23:00:00.000Z",
+		location)
+	i := intervals.NewInterval()
+	i.SetInterval(start, end)
+	interval := intervals.NewIntervals().SetIntervals([]*intervals.Interval{i})
+
+	selectorExtractionFn := extractionfn.NewLower().SetLocale("")
+	a := filter.NewSelector().SetDimension("countryName").SetValue("france").
+		SetExtractionFn(selectorExtractionFn)
+	query.NewSegmentMetadata().SetIntervals(interval)
+	datasourceSubQuery := query.NewScan().
+		SetDataSource(datasource2.NewTable().SetName("A")).SetColumns([]string{"AT"}).
+		SetIntervals(interval)
+	datasource := datasource2.NewQuery().SetQuery(datasourceSubQuery)
+	scan := query.NewScan()
+	queryTest := scan.SetLimit(10).SetIntervals(interval).SetFilter(a).
+		SetColumns([]string{"__time", "channel", "cityName", "comment", "count", "countryIsoCode",
+			"diffUrl", "flags", "isAnonymous", "isMinor", "isNew", "isRobot", "isUnpatrolled",
+			"metroCode", "namespace", "page", "regionIsoCode", "regionName", "sum_added",
+			"sum_commentLength", "sum_deleted", "sum_delta", "sum_deltaBucket", "user"}).
+		SetBatchSize(20480).
+		SetDataSource(datasource)
+	// If you include ordering, you'll get an error.
+	// .SetOrder(query.Descending)
+	return queryTest
+}
+
+// MakeTimeSeriesSubQuery Results are timestamp 2022-10-07 ~ 13
+func MakeTimeSeriesSubQuery() *query.Timeseries {
+	location, _ := time.LoadLocation("UTC")
+	start, _ := time.ParseInLocation(time.RFC3339,
+		"2022-10-07T00:00:00Z",
+		location)
+	i := intervals.NewInterval()
+	i.SetInterval(start, start.Add(time.Hour*24*7))
+	interval := intervals.NewIntervals().SetIntervals([]*intervals.Interval{i})
+	topN := query.NewTopN().
+		SetThreshold(100).
+		SetMetric(topnmetric.NewNumeric().SetMetric("count")).
+		SetIntervals(interval).
+		SetGranularity(granularity.NewSimple().SetGranularity(granularity.Day)).
+		SetDimension(dimension.NewDefault().SetDimension("string_value")).
+		SetDataSource(datasource2.NewTable().SetName("dc_94b4f5fdfde940979b79c50539d8322a_b42fde98efed4e638a0016b34b3c10cf_dataset_pre")).
+		SetAggregations([]builder.Aggregator{aggregation.NewLongSum().SetName("count").SetFieldName("count")}).
+		SetFilter(filter.NewAnd().SetFields([]builder.Filter{filter.NewSelector().SetDimension("_split_name_").SetValue("train"),
+			filter.NewSelector().SetDimension("column_name").SetValue("addressState")}))
+	subQuery := datasource2.NewQuery().SetQuery(topN)
+	queryTest := query.NewTimeseries().SetGranularity(granularity.NewSimple().SetGranularity(granularity.Day)).
+		SetIntervals(interval).SetDataSource(subQuery)
+	return queryTest
+}

--- a/examples/subqueryExample.go
+++ b/examples/subqueryExample.go
@@ -69,9 +69,7 @@ func MakeScanSubQuery() *query.Scan {
 			"metroCode", "namespace", "page", "regionIsoCode", "regionName", "sum_added",
 			"sum_commentLength", "sum_deleted", "sum_delta", "sum_deltaBucket", "user"}).
 		SetBatchSize(20480).
-		SetDataSource(datasource)
-	// If you include ordering, you'll get an error.
-	// .SetOrder(query.Descending)
+		SetDataSource(datasource).SetOrder(query.None)
 	return queryTest
 }
 

--- a/examples/subquery_test.go
+++ b/examples/subquery_test.go
@@ -1,0 +1,204 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/grafadruid/go-druid/builder"
+	"github.com/grafadruid/go-druid/builder/aggregation"
+	datasource2 "github.com/grafadruid/go-druid/builder/datasource"
+	"github.com/grafadruid/go-druid/builder/dimension"
+	"github.com/grafadruid/go-druid/builder/extractionfn"
+	"github.com/grafadruid/go-druid/builder/filter"
+	"github.com/grafadruid/go-druid/builder/granularity"
+	"github.com/grafadruid/go-druid/builder/intervals"
+	"github.com/grafadruid/go-druid/builder/query"
+	"github.com/grafadruid/go-druid/builder/topnmetric"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestSubQueryScan(t *testing.T) {
+	expected := `{
+  "batchSize": 20480,
+  "columns": [
+    "__time",
+    "channel",
+    "cityName",
+    "comment",
+    "count",
+    "countryIsoCode",
+    "diffUrl",
+    "flags",
+    "isAnonymous",
+    "isMinor",
+    "isNew",
+    "isRobot",
+    "isUnpatrolled",
+    "metroCode",
+    "namespace",
+    "page",
+    "regionIsoCode",
+    "regionName",
+    "sum_added",
+    "sum_commentLength",
+    "sum_deleted",
+    "sum_delta",
+    "sum_deltaBucket",
+    "user"
+  ],
+  "dataSource": {
+    "type": "query",
+    "query": {
+      "queryType": "scan",
+      "dataSource": {
+        "type": "table",
+        "name": "A"
+      },
+      "columns": [
+        "AT"
+      ],
+      "intervals": {
+        "type": "intervals",
+        "intervals": [
+          "1980-06-12T22:30:00Z/2020-01-26T23:00:00Z"
+        ]
+      }
+    }
+  },
+  "filter": {
+    "dimension": "countryName",
+    "extractionFn": {
+      "locale": "",
+      "type": "lower"
+    },
+    "type": "selector",
+    "value": "france"
+  },
+  "intervals": {
+    "type": "intervals",
+    "intervals": [
+      "1980-06-12T22:30:00Z/2020-01-26T23:00:00Z"
+    ]
+  },
+  "limit": 10,
+  "order": "DESCENDING",
+  "queryType": "scan"
+}`
+	location, _ := time.LoadLocation("UTC")
+
+	start, _ := time.ParseInLocation(time.RFC3339Nano,
+		"1980-06-12T22:30:00.000Z",
+		location)
+	end, _ := time.ParseInLocation(time.RFC3339Nano,
+		"2020-01-26T23:00:00.000Z",
+		location)
+	i := intervals.NewInterval()
+	i.SetInterval(start, end)
+	interval := intervals.NewIntervals().SetIntervals([]*intervals.Interval{i})
+
+	selectorExtractionFn := extractionfn.NewLower().SetLocale("")
+	a := filter.NewSelector().SetDimension("countryName").SetValue("france").
+		SetExtractionFn(selectorExtractionFn)
+
+	datasourceSubQuery := query.NewScan().
+		SetDataSource(datasource2.NewTable().SetName("A")).SetColumns([]string{"AT"}).
+		SetIntervals(interval)
+	datasource := datasource2.NewQuery().SetQuery(datasourceSubQuery)
+	scan := query.NewScan()
+	queryTest := scan.SetOrder(query.Descending).SetLimit(10).SetIntervals(interval).SetFilter(a).
+		SetColumns([]string{"__time", "channel", "cityName", "comment", "count", "countryIsoCode",
+			"diffUrl", "flags", "isAnonymous", "isMinor", "isNew", "isRobot", "isUnpatrolled",
+			"metroCode", "namespace", "page", "regionIsoCode", "regionName", "sum_added",
+			"sum_commentLength", "sum_deleted", "sum_delta", "sum_deltaBucket", "user"}).
+		SetBatchSize(20480).
+		SetDataSource(datasource)
+
+	queryTestJSON, err := json.Marshal(queryTest)
+	assert.Nil(t, err)
+
+	assert.JSONEq(t, expected, string(queryTestJSON))
+}
+
+func TestSubQueryTimeseries(t *testing.T) {
+	expected := `{
+	"dataSource": {
+		"query": {
+			"aggregations": [{
+				"fieldName": "count",
+				"name": "count",
+				"type": "longSum"
+			}],
+			"dataSource": {
+				"name": "dc_94b4f5fdfde940979b79c50539d8322a_b42fde98efed4e638a0016b34b3c10cf_dataset_pre",
+				"type": "table"
+			},
+			"dimension": {
+				"dimension": "string_value",
+				"type": "default"
+			},
+			"filter": {
+				"fields": [{
+						"dimension": "_split_name_",
+						"type": "selector",
+						"value": "train"
+					},
+					{
+						"dimension": "column_name",
+						"type": "selector",
+						"value": "addressState"
+					}
+				],
+				"type": "and"
+			},
+			"granularity": "day",
+			"intervals": {
+				"intervals": [
+					"2022-10-07T00:00:00Z/2022-10-14T00:00:00Z"
+				],
+				"type": "intervals"
+			},
+			"metric": {
+				"metric": "count",
+				"type": "numeric"
+			},
+			"queryType": "topN",
+			"threshold": 100
+		},
+		"type": "query"
+	},
+	"granularity": "day",
+	"intervals": {
+		"intervals": [
+			"2022-10-07T00:00:00Z/2022-10-14T00:00:00Z"
+		],
+		"type": "intervals"
+	},
+	"queryType": "timeseries"
+}`
+	location, _ := time.LoadLocation("UTC")
+	start, _ := time.ParseInLocation(time.RFC3339,
+		"2022-10-07T00:00:00Z",
+		location)
+	i := intervals.NewInterval()
+	i.SetInterval(start, start.Add(time.Hour*24*7))
+	interval := intervals.NewIntervals().SetIntervals([]*intervals.Interval{i})
+	topN := query.NewTopN().
+		SetThreshold(100).
+		SetMetric(topnmetric.NewNumeric().SetMetric("count")).
+		SetIntervals(interval).
+		SetGranularity(granularity.NewSimple().SetGranularity(granularity.Day)).
+		SetDimension(dimension.NewDefault().SetDimension("string_value")).
+		SetDataSource(datasource2.NewTable().SetName("dc_94b4f5fdfde940979b79c50539d8322a_b42fde98efed4e638a0016b34b3c10cf_dataset_pre")).
+		SetAggregations([]builder.Aggregator{aggregation.NewLongSum().SetName("count").SetFieldName("count")}).
+		SetFilter(filter.NewAnd().SetFields([]builder.Filter{filter.NewSelector().SetDimension("_split_name_").SetValue("train"),
+			filter.NewSelector().SetDimension("column_name").SetValue("addressState")}))
+	subQuery := datasource2.NewQuery().SetQuery(topN)
+	queryTest := query.NewTimeseries().SetGranularity(granularity.NewSimple().SetGranularity(granularity.Day)).
+		SetIntervals(interval).SetDataSource(subQuery)
+
+	queryTestJSON, err := json.Marshal(queryTest)
+	assert.Nil(t, err)
+
+	assert.JSONEq(t, expected, string(queryTestJSON))
+
+}


### PR DESCRIPTION
Hi, I wrote a test code for subquery. #15 #78 

@jbguerraz @saketbairoliya2 @vigith 

There were two code modifications.
1. Query struct : "-,omitempty" -> "query,omitempty"
```go
type Query struct {
	Base
	Query builder.Query `json:"query,omitempty"`
}
```
This is necessary to make a subquery.

2. Lower struct : "locale,omitempty" -> "locale"
```go
type Lower struct {
	Base
	Locale string `json:"locale"`
}
```
```json
"extractionFn": {
"locale": "",
"type": "lower"
},
```
To express this example code,
