### PR TITLE
Enable sql queries for Imply Polaris projects

### DIFF
--- a/common.go
+++ b/common.go
@@ -2,6 +2,7 @@ package druid
 
 const (
 	StatusEndpoint         = "status"
+	PolarisStatusEndpoint         = "v1/apikeyinfo"
 	HealthEndpoint         = "status/health"
 	PropertiesEndpoint     = "status/properties"
 	SelfDiscoveredEndpoint = "status/selfDiscovered/status"
@@ -34,7 +35,13 @@ type CommonService struct {
 
 func (c *CommonService) Status() (*Status, *Response, error) {
 	var s *Status
-	response, err := c.client.ExecuteRequest("GET", StatusEndpoint, nil, &s)
+	var path string
+	if c.client.polarisConnection {
+		path = PolarisStatusEndpoint
+	} else {
+		path = StatusEndpoint
+	}
+	response, err := c.client.ExecuteRequest("GET", path, nil, &s)
 	if err != nil {
 		return nil, response, err
 	}

--- a/druid.go
+++ b/druid.go
@@ -48,23 +48,25 @@ var (
 )
 
 type Client struct {
-	http      *retryablehttp.Client
-	baseURL   *url.URL
-	username  string
-	password  string
-	basicAuth bool
+	http              *retryablehttp.Client
+	baseURL           *url.URL
+	username          string
+	password          string
+	basicAuth         bool
+	polarisConnection bool
 }
 
 type clientOptions struct {
-	httpClient   *http.Client
-	username     string
-	password     string
-	backoff      retryablehttp.Backoff
-	errorHandler retryablehttp.ErrorHandler
-	retry        retryablehttp.CheckRetry
-	retryWaitMin time.Duration
-	retryWaitMax time.Duration
-	retryMax     int
+	httpClient        *http.Client
+	username          string
+	password          string
+	backoff           retryablehttp.Backoff
+	errorHandler      retryablehttp.ErrorHandler
+	retry             retryablehttp.CheckRetry
+	retryWaitMin      time.Duration
+	retryWaitMax      time.Duration
+	retryMax          int
+	polarisConnection bool
 }
 
 type ClientOption func(*clientOptions)
@@ -89,6 +91,7 @@ func NewClient(baseURL string, options ...ClientOption) (*Client, error) {
 	for _, opt := range options {
 		opt(opts)
 	}
+
 	c := &Client{
 		http: &retryablehttp.Client{
 			Backoff:      opts.backoff,
@@ -98,9 +101,10 @@ func NewClient(baseURL string, options ...ClientOption) (*Client, error) {
 			RetryWaitMax: opts.retryWaitMax,
 			RetryMax:     opts.retryMax,
 		},
-		username:  opts.username,
-		password:  opts.password,
-		basicAuth: opts.username != "" && opts.password != "",
+		username:          opts.username,
+		password:          opts.password,
+		basicAuth:         opts.username != "" && opts.password != "",
+		polarisConnection: opts.polarisConnection,
 	}
 	if err := c.setBaseURL(baseURL); err != nil {
 		return nil, err
@@ -335,6 +339,12 @@ func WithRetryWaitMax(retryWaitMax time.Duration) ClientOption {
 func WithRetryMax(retryMax int) ClientOption {
 	return func(opts *clientOptions) {
 		opts.retryMax = retryMax
+	}
+}
+
+func WithPolarisConnection(usePolaris bool) ClientOption {
+	return func(opts *clientOptions) {
+		opts.polarisConnection = usePolaris
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/grafadruid/go-druid
+module github.com/jonah-rankin/go-druid
 
 go 1.14
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jonah-rankin/go-druid
+module github.com/grafadruid/go-druid
 
 go 1.14
 

--- a/query.go
+++ b/query.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	NativeQueryEndpoint = "druid/v2"
-	SQLQueryEndpoint    = "druid/v2/sql"
+	NativeQueryEndpoint     = "druid/v2"
+	SQLQueryEndpoint        = "druid/v2/sql"
+	PolarisSQLQueryEndpoint = "v1/query/sql"
 )
 
 type QueryService struct {
@@ -20,7 +21,11 @@ func (q *QueryService) Execute(qry builder.Query, result interface{}, headers ..
 	var path string
 	switch qry.Type() {
 	case "sql":
-		path = SQLQueryEndpoint
+		if q.client.polarisConnection {
+			path = PolarisSQLQueryEndpoint
+		} else {
+			path = SQLQueryEndpoint
+		}
 	default:
 		path = NativeQueryEndpoint
 	}


### PR DESCRIPTION
Polaris projects do not expose the native Druid endpoints, instead SQL queries use `v1/query/sql` when `polarisConnection` is `true`.

Change summary:
* Add `polarisConnection` client option
* Add WithPolarisConnection method to set the `polarisConnection` option
* Use Polaris sql query path when `polarisConnection` is set enabled

Usage with a Polaris project:
* Authenticate with [Polaris API keys](https://docs.imply.io/polaris/api-keys/)
  * Use `basic` authentication
  * Username `APIKEY` and password as your Polaris API key.
* The `baseUrl` will be `https://ORGANIZATION_NAME.REGION.CLOUD_PROVIDER.api.imply.io` or `https://ORGANIZATION_NAME.api.imply.io` see the [Query API docs](https://docs.imply.io/polaris/QueryApi/) for more information.