### PR TITLE
Handling the Gateway Timeout Unmarshaling Error

### DIFF
--- a/Magefile.go
+++ b/Magefile.go
@@ -77,7 +77,7 @@ func Fmt() error {
 	return nil
 }
 
-//  Vet run go vet linter
+// Vet run go vet linter
 func Vet() error {
 	if err := sh.Run(goexe, "vet", "./..."); err != nil {
 		return fmt.Errorf("error running go vet: %v", err)
@@ -153,7 +153,7 @@ func Build() error {
 }
 
 var (
-	pkgPrefixLen = len("github.com/grafadruid/go-druid")
+	pkgPrefixLen = len("github.com/adjoeio/go-druid")
 	pkgs         []string
 	pkgsInit     sync.Once
 )

--- a/builder/aggregation/aggregation.go
+++ b/builder/aggregation/aggregation.go
@@ -108,8 +108,10 @@ func Load(data []byte) (builder.Aggregator, error) {
 		a = NewQuantilesDoublesSketch()
 	case "thetaSketch":
 		a = NewThetaSketch()
+	case "":
+		return nil, errors.New("missing aggregation type")
 	default:
-		return nil, errors.New("unsupported aggregation type")
+		a = builder.NewSpec(t.Typ)
 	}
 	return a, json.Unmarshal(data, &a)
 }

--- a/builder/aggregation/aggregation.go
+++ b/builder/aggregation/aggregation.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Base struct {

--- a/builder/aggregation/aggregation_test.go
+++ b/builder/aggregation/aggregation_test.go
@@ -1,17 +1,232 @@
 package aggregation
 
 import (
+	"github.com/grafadruid/go-druid/builder"
+	"github.com/grafadruid/go-druid/builder/filter"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLoadUnsupportedType(t *testing.T) {
+func TestLoadInvalidJSON(t *testing.T) {
 	assert := assert.New(t)
 
-	f, err := Load([]byte("{\"type\": \"blahblahType\"}"))
+	f, err := Load([]byte("not JSON value"))
 
-	assert.Nil(f, "filter should be nil")
-	assert.NotNil(err, "error should not be nil")
-	assert.Error(err, "unsupported aggregation type")
+	assert.Nilf(f, "aggregation should be nil")
+	assert.Errorf(err, "loading should return a non-nil error")
+}
+
+func TestLoadUntypedJSON(t *testing.T) {
+	assert := assert.New(t)
+
+	f, err := Load([]byte("{}"))
+
+	assert.Nilf(f, "aggregation should be nil")
+	assert.Errorf(err, "loading should return a non-nil error")
+}
+
+func TestLoadValidAggregation(t *testing.T) {
+	tests := []struct {
+		name     string
+		jsonData string
+		expected builder.Aggregator
+	}{
+		{
+			name:     "cardinality",
+			jsonData: `{"type": "cardinality"}`,
+			expected: NewCardinality(),
+		},
+		{
+			name:     "count",
+			jsonData: `{"type": "count"}`,
+			expected: NewCount(),
+		},
+		{
+			name:     "doubleAny",
+			jsonData: `{"type": "doubleAny"}`,
+			expected: NewDoubleAny(),
+		},
+		{
+			name:     "doubleFirst",
+			jsonData: `{"type": "doubleFirst"}`,
+			expected: NewDoubleFirst(),
+		},
+		{
+			name:     "doubleLast",
+			jsonData: `{"type": "doubleLast"}`,
+			expected: NewDoubleLast(),
+		},
+		{
+			name:     "doubleMax",
+			jsonData: `{"type": "doubleMax"}`,
+			expected: NewDoubleMax(),
+		},
+		{
+			name:     "doubleMean",
+			jsonData: `{"type": "doubleMean"}`,
+			expected: NewDoubleMean(),
+		},
+		{
+			name:     "doubleMin",
+			jsonData: `{"type": "doubleMin"}`,
+			expected: NewDoubleMin(),
+		},
+		{
+			name:     "doubleSum",
+			jsonData: `{"type": "doubleSum"}`,
+			expected: NewDoubleSum(),
+		},
+		{
+			name: "filtered",
+			jsonData: `{
+				"type": "filtered",
+				"aggregator": {"type":"count"},
+				"filter": {"type": "true"}
+			}`,
+			expected: NewFiltered().
+				SetAggregator(NewCount()).
+				SetFilter(filter.NewTrue()),
+		},
+		{
+			name:     "floatAny",
+			jsonData: `{"type": "floatAny"}`,
+			expected: NewFloatAny(),
+		},
+		{
+			name:     "floatFirst",
+			jsonData: `{"type": "floatFirst"}`,
+			expected: NewFloatFirst(),
+		},
+		{
+			name:     "floatLast",
+			jsonData: `{"type": "floatLast"}`,
+			expected: NewFloatLast(),
+		},
+		{
+			name:     "floatMax",
+			jsonData: `{"type": "floatMax"}`,
+			expected: NewFloatMax(),
+		},
+		{
+			name:     "floatMin",
+			jsonData: `{"type": "floatMin"}`,
+			expected: NewFloatMin(),
+		},
+		{
+			name:     "floatSum",
+			jsonData: `{"type": "floatSum"}`,
+			expected: NewFloatSum(),
+		},
+		{
+			name:     "histogram",
+			jsonData: `{"type": "histogram"}`,
+			expected: NewHistogram(),
+		},
+		{
+			name:     "HLLSketchBuild",
+			jsonData: `{"type": "HLLSketchBuild"}`,
+			expected: NewHLLSketchBuild(),
+		},
+		{
+			name:     "HLLSketchMerge",
+			jsonData: `{"type": "HLLSketchMerge"}`,
+			expected: NewHLLSketchMerge(),
+		},
+		{
+			name:     "hyperUnique",
+			jsonData: `{"type": "hyperUnique"}`,
+			expected: NewHyperUnique(),
+		},
+		{
+			name:     "javascript",
+			jsonData: `{"type": "javascript"}`,
+			expected: NewJavascript(),
+		},
+		{
+			name:     "longAny",
+			jsonData: `{"type": "longAny"}`,
+			expected: NewLongAny(),
+		},
+		{
+			name:     "longFirst",
+			jsonData: `{"type": "longFirst"}`,
+			expected: NewLongFirst(),
+		},
+		{
+			name:     "longLast",
+			jsonData: `{"type": "longLast"}`,
+			expected: NewLongLast(),
+		},
+		{
+			name:     "longMax",
+			jsonData: `{"type": "longMax"}`,
+			expected: NewLongMax(),
+		},
+		{
+			name:     "longMin",
+			jsonData: `{"type": "longMin"}`,
+			expected: NewLongMin(),
+		},
+		{
+			name:     "longSum",
+			jsonData: `{"type": "longSum"}`,
+			expected: NewLongSum(),
+		},
+		{
+			name:     "stringAny",
+			jsonData: `{"type": "stringAny"}`,
+			expected: NewStringAny(),
+		},
+		{
+			name:     "stringFirstFolding",
+			jsonData: `{"type": "stringFirstFolding"}`,
+			expected: NewStringFirstFolding(),
+		},
+		{
+			name:     "stringFirst",
+			jsonData: `{"type": "stringFirst"}`,
+			expected: NewStringFirst(),
+		},
+		{
+			name:     "stringLastFolding",
+			jsonData: `{"type": "stringLastFolding"}`,
+			expected: NewStringLastFolding(),
+		},
+		{
+			name:     "stringLast",
+			jsonData: `{"type": "stringLast"}`,
+			expected: NewStringLast(),
+		},
+		{
+			name:     "tDigestSketch",
+			jsonData: `{"type": "tDigestSketch"}`,
+			expected: NewTDigestSketch(),
+		},
+		{
+			name:     "quantilesDoublesSketch",
+			jsonData: `{"type": "quantilesDoublesSketch"}`,
+			expected: NewQuantilesDoublesSketch(),
+		},
+		{
+			name:     "thetaSketch",
+			jsonData: `{"type": "thetaSketch"}`,
+			expected: NewThetaSketch(),
+		},
+		{
+			name:     "unknown aggregator",
+			jsonData: `{"type": "blahblahType"}`,
+			expected: builder.NewSpec("blahblahType"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			a, err := Load([]byte(test.jsonData))
+
+			assert.NoErrorf(err, "loading a valid aggregation should not fail")
+			assert.Equal(test.expected, a)
+		})
+	}
 }

--- a/builder/aggregation/aggregation_test.go
+++ b/builder/aggregation/aggregation_test.go
@@ -1,10 +1,10 @@
 package aggregation
 
 import (
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/filter"
 	"testing"
 
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/filter"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/builder/aggregation/filtered.go
+++ b/builder/aggregation/filtered.go
@@ -2,8 +2,9 @@ package aggregation
 
 import (
 	"encoding/json"
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/filter"
+
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/filter"
 )
 
 type Filtered struct {

--- a/builder/aggregation/filtered_test.go
+++ b/builder/aggregation/filtered_test.go
@@ -2,10 +2,11 @@ package aggregation
 
 import (
 	"encoding/json"
-	"github.com/grafadruid/go-druid/builder/filter"
-	"github.com/grafadruid/go-druid/builder/types"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/adjoeio/go-druid/builder/filter"
+	"github.com/adjoeio/go-druid/builder/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadFilteredAggregator(t *testing.T) {

--- a/builder/bound/bound.go
+++ b/builder/bound/bound.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Base struct {

--- a/builder/datasource/data_source.go
+++ b/builder/datasource/data_source.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Base struct {

--- a/builder/datasource/join.go
+++ b/builder/datasource/join.go
@@ -3,8 +3,8 @@ package datasource
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/types"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/types"
 )
 
 type Join struct {

--- a/builder/datasource/query.go
+++ b/builder/datasource/query.go
@@ -2,13 +2,12 @@ package datasource
 
 import (
 	"encoding/json"
-
 	"github.com/grafadruid/go-druid/builder"
 )
 
 type Query struct {
 	Base
-	Query builder.Query `json:"-,omitempty"`
+	Query builder.Query `json:"query,omitempty"`
 }
 
 func NewQuery() *Query {
@@ -17,8 +16,9 @@ func NewQuery() *Query {
 	return q
 }
 
-func (q *Query) SetQuery(qry builder.Query) {
+func (q *Query) SetQuery(qry builder.Query) *Query {
 	q.Query = qry
+	return q
 }
 
 func (q *Query) UnmarshalJSONWithQueryLoader(data []byte, loader func(data []byte) (builder.Query, error)) error {

--- a/builder/datasource/query.go
+++ b/builder/datasource/query.go
@@ -2,7 +2,8 @@ package datasource
 
 import (
 	"encoding/json"
-	"github.com/grafadruid/go-druid/builder"
+
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Query struct {

--- a/builder/dimension/default.go
+++ b/builder/dimension/default.go
@@ -1,6 +1,6 @@
 package dimension
 
-import "github.com/grafadruid/go-druid/builder/types"
+import "github.com/adjoeio/go-druid/builder/types"
 
 type Default struct {
 	Base

--- a/builder/dimension/dimension.go
+++ b/builder/dimension/dimension.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/types"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/types"
 )
 
 type Base struct {

--- a/builder/dimension/extraction.go
+++ b/builder/dimension/extraction.go
@@ -3,8 +3,8 @@ package dimension
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/types"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/types"
 )
 
 type Extraction struct {

--- a/builder/dimension/list_filtered.go
+++ b/builder/dimension/list_filtered.go
@@ -3,8 +3,8 @@ package dimension
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/types"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/types"
 )
 
 type ListFiltered struct {

--- a/builder/dimension/lookup.go
+++ b/builder/dimension/lookup.go
@@ -3,8 +3,8 @@ package dimension
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/lookup"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/lookup"
 )
 
 type Lookup struct {

--- a/builder/dimension/prefix_filtered.go
+++ b/builder/dimension/prefix_filtered.go
@@ -3,8 +3,8 @@ package dimension
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/types"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/types"
 )
 
 type PrefixFiltered struct {

--- a/builder/dimension/regex_filtered.go
+++ b/builder/dimension/regex_filtered.go
@@ -3,8 +3,8 @@ package dimension
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/types"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/types"
 )
 
 type RegexFiltered struct {

--- a/builder/extractionfn/cascade.go
+++ b/builder/extractionfn/cascade.go
@@ -3,7 +3,7 @@ package extractionfn
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Cascade struct {

--- a/builder/extractionfn/extraction_fn.go
+++ b/builder/extractionfn/extraction_fn.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Base struct {

--- a/builder/extractionfn/lookup.go
+++ b/builder/extractionfn/lookup.go
@@ -3,8 +3,8 @@ package extractionfn
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/lookup"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/lookup"
 )
 
 type Lookup struct {
@@ -46,6 +46,7 @@ func (l *Lookup) SetOptimize(optimize bool) *Lookup {
 	l.Optimize = &optimize
 	return l
 }
+
 func (l *Lookup) UnmarshalJSON(data []byte) error {
 	var tmp struct {
 		Base

--- a/builder/extractionfn/search_query.go
+++ b/builder/extractionfn/search_query.go
@@ -3,8 +3,8 @@ package extractionfn
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/searchqueryspec"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/searchqueryspec"
 )
 
 type SearchQuery struct {

--- a/builder/extractionfn/string_format.go
+++ b/builder/extractionfn/string_format.go
@@ -1,7 +1,7 @@
 package extractionfn
 
 import (
-	"github.com/grafadruid/go-druid/builder/types"
+	"github.com/adjoeio/go-druid/builder/types"
 )
 
 type StringFormat struct {

--- a/builder/extractionfn/time_format.go
+++ b/builder/extractionfn/time_format.go
@@ -3,8 +3,8 @@ package extractionfn
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/types"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/types"
 )
 
 type TimeFormat struct {

--- a/builder/filter/and.go
+++ b/builder/filter/and.go
@@ -3,7 +3,7 @@ package filter
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type And struct {

--- a/builder/filter/bound.go
+++ b/builder/filter/bound.go
@@ -3,9 +3,9 @@ package filter
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/extractionfn"
-	"github.com/grafadruid/go-druid/builder/types"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/extractionfn"
+	"github.com/adjoeio/go-druid/builder/types"
 )
 
 type Bound struct {

--- a/builder/filter/column_comparison.go
+++ b/builder/filter/column_comparison.go
@@ -3,8 +3,8 @@ package filter
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/dimension"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/dimension"
 )
 
 type ColumnComparison struct {

--- a/builder/filter/extraction.go
+++ b/builder/filter/extraction.go
@@ -3,8 +3,8 @@ package filter
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/extractionfn"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/extractionfn"
 )
 
 type Extraction struct {

--- a/builder/filter/filter.go
+++ b/builder/filter/filter.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Base struct {

--- a/builder/filter/filter_test.go
+++ b/builder/filter/filter_test.go
@@ -2,11 +2,12 @@ package filter
 
 import (
 	"encoding/json"
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/intervals"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/intervals"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadUnsupportedType(t *testing.T) {

--- a/builder/filter/in.go
+++ b/builder/filter/in.go
@@ -3,8 +3,8 @@ package filter
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/extractionfn"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/extractionfn"
 )
 
 type In struct {

--- a/builder/filter/interval.go
+++ b/builder/filter/interval.go
@@ -3,9 +3,9 @@ package filter
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/extractionfn"
-	"github.com/grafadruid/go-druid/builder/intervals"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/extractionfn"
+	"github.com/adjoeio/go-druid/builder/intervals"
 )
 
 type Interval struct {

--- a/builder/filter/javascript.go
+++ b/builder/filter/javascript.go
@@ -3,8 +3,8 @@ package filter
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/extractionfn"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/extractionfn"
 )
 
 type Javascript struct {

--- a/builder/filter/like.go
+++ b/builder/filter/like.go
@@ -3,8 +3,8 @@ package filter
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/extractionfn"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/extractionfn"
 )
 
 type Like struct {

--- a/builder/filter/not.go
+++ b/builder/filter/not.go
@@ -3,7 +3,7 @@ package filter
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Not struct {

--- a/builder/filter/or.go
+++ b/builder/filter/or.go
@@ -2,7 +2,8 @@ package filter
 
 import (
 	"encoding/json"
-	"github.com/grafadruid/go-druid/builder"
+
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Or struct {

--- a/builder/filter/regex.go
+++ b/builder/filter/regex.go
@@ -3,8 +3,8 @@ package filter
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/extractionfn"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/extractionfn"
 )
 
 type Regex struct {

--- a/builder/filter/search.go
+++ b/builder/filter/search.go
@@ -3,8 +3,8 @@ package filter
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/extractionfn"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/extractionfn"
 )
 
 type Search struct {

--- a/builder/filter/selector.go
+++ b/builder/filter/selector.go
@@ -3,8 +3,8 @@ package filter
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/extractionfn"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/extractionfn"
 )
 
 type Selector struct {

--- a/builder/filter/spatial.go
+++ b/builder/filter/spatial.go
@@ -3,8 +3,8 @@ package filter
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/bound"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/bound"
 )
 
 type Spatial struct {

--- a/builder/granularity/granularity.go
+++ b/builder/granularity/granularity.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"strconv"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 // Base is the base for granularity.

--- a/builder/granularity/period.go
+++ b/builder/granularity/period.go
@@ -3,7 +3,7 @@ package granularity
 import (
 	"time"
 
-	"github.com/grafadruid/go-druid/builder/types"
+	"github.com/adjoeio/go-druid/builder/types"
 )
 
 // Period granularity is specified as arbitrary period combinations of years, months, weeks, hours, minutes and seconds

--- a/builder/granularity/simple.go
+++ b/builder/granularity/simple.go
@@ -1,6 +1,6 @@
 package granularity
 
-import "github.com/grafadruid/go-druid/builder"
+import "github.com/adjoeio/go-druid/builder"
 
 // Simple granularities are specified as a string and bucket timestamps by their UTC time.
 // https://druid.apache.org/docs/latest/querying/granularities.html#simple-granularities

--- a/builder/granularity/simple_test.go
+++ b/builder/granularity/simple_test.go
@@ -1,9 +1,10 @@
 package granularity
 
 import (
-	"github.com/grafadruid/go-druid/builder/testutil"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/adjoeio/go-druid/builder/testutil"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewSimple(t *testing.T) {

--- a/builder/havingspec/and.go
+++ b/builder/havingspec/and.go
@@ -3,7 +3,7 @@ package havingspec
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type And struct {

--- a/builder/havingspec/dim_selector.go
+++ b/builder/havingspec/dim_selector.go
@@ -3,8 +3,8 @@ package havingspec
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/extractionfn"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/extractionfn"
 )
 
 type DimSelector struct {

--- a/builder/havingspec/having_spec.go
+++ b/builder/havingspec/having_spec.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Base struct {

--- a/builder/havingspec/not.go
+++ b/builder/havingspec/not.go
@@ -3,7 +3,7 @@ package havingspec
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Not struct {

--- a/builder/havingspec/or.go
+++ b/builder/havingspec/or.go
@@ -3,7 +3,7 @@ package havingspec
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Or struct {

--- a/builder/intervals/intervals.go
+++ b/builder/intervals/intervals.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Base struct {

--- a/builder/limitspec/default.go
+++ b/builder/limitspec/default.go
@@ -1,7 +1,7 @@
 package limitspec
 
 import (
-	"github.com/grafadruid/go-druid/builder/types"
+	"github.com/adjoeio/go-druid/builder/types"
 )
 
 type Direction string

--- a/builder/limitspec/limit_spec.go
+++ b/builder/limitspec/limit_spec.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Base struct {

--- a/builder/lookup/lookup.go
+++ b/builder/lookup/lookup.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Base struct {

--- a/builder/postaggregation/arithmetic.go
+++ b/builder/postaggregation/arithmetic.go
@@ -3,7 +3,7 @@ package postaggregation
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Arithmetic struct {

--- a/builder/postaggregation/double_greatest.go
+++ b/builder/postaggregation/double_greatest.go
@@ -3,7 +3,7 @@ package postaggregation
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type DoubleGreatest struct {

--- a/builder/postaggregation/double_least.go
+++ b/builder/postaggregation/double_least.go
@@ -3,7 +3,7 @@ package postaggregation
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type DoubleLeast struct {

--- a/builder/postaggregation/long_greatest.go
+++ b/builder/postaggregation/long_greatest.go
@@ -3,7 +3,7 @@ package postaggregation
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type LongGreatest struct {

--- a/builder/postaggregation/long_least.go
+++ b/builder/postaggregation/long_least.go
@@ -3,7 +3,7 @@ package postaggregation
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type LongLeast struct {

--- a/builder/postaggregation/post_aggregator.go
+++ b/builder/postaggregation/post_aggregator.go
@@ -76,8 +76,10 @@ func Load(data []byte) (builder.PostAggregator, error) {
 		p = NewQuantilesDoublesSketchToCDF()
 	case "quantilesDoublesSketchToString":
 		p = NewQuantilesDoublesSketchToString()
+	case "":
+		return nil, errors.New("missing postaggregation type")
 	default:
-		return nil, errors.New("unsupported postaggregation type")
+		p = builder.NewSpec(t.Typ)
 	}
 	return p, json.Unmarshal(data, &p)
 }

--- a/builder/postaggregation/post_aggregator.go
+++ b/builder/postaggregation/post_aggregator.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Base struct {

--- a/builder/postaggregation/post_aggregator_test.go
+++ b/builder/postaggregation/post_aggregator_test.go
@@ -1,9 +1,10 @@
 package postaggregation
 
 import (
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestLoadInvalidJSON(t *testing.T) {

--- a/builder/postaggregation/post_aggregator_test.go
+++ b/builder/postaggregation/post_aggregator_test.go
@@ -1,17 +1,144 @@
 package postaggregation
 
 import (
-	"testing"
-
+	"github.com/grafadruid/go-druid/builder"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
-func TestLoadUnsupportedType(t *testing.T) {
+func TestLoadInvalidJSON(t *testing.T) {
 	assert := assert.New(t)
 
-	f, err := Load([]byte("{\"type\": \"blahblahType\"}"))
+	f, err := Load([]byte("not JSON value"))
 
-	assert.Nil(f, "filter should be nil")
-	assert.NotNil(err, "error should not be nil")
-	assert.Error(err, "unsupported postaggregation type")
+	assert.Nilf(f, "post aggregation should be nil")
+	assert.Errorf(err, "loading should return a non-nil error")
+}
+
+func TestLoadUntypedJSON(t *testing.T) {
+	assert := assert.New(t)
+
+	f, err := Load([]byte("{}"))
+
+	assert.Nilf(f, "post aggregation should be nil")
+	assert.Errorf(err, "loading should return a non-nil error")
+}
+
+func TestLoadValidAggregation(t *testing.T) {
+	tests := []struct {
+		name     string
+		jsonData string
+		expected builder.Aggregator
+	}{
+		{
+			name:     "arithmetic",
+			jsonData: `{"type":"arithmetic"}`,
+			expected: NewArithmetic().SetFields([]builder.PostAggregator{}),
+		},
+		{
+			name:     "constant",
+			jsonData: `{"type":"constant"}`,
+			expected: NewConstant(),
+		},
+		{
+			name:     "doubleGreatest",
+			jsonData: `{"type":"doubleGreatest"}`,
+			expected: NewDoubleGreatest().SetFields([]builder.PostAggregator{}),
+		},
+		{
+			name:     "doubleLeast",
+			jsonData: `{"type":"doubleLeast"}`,
+			expected: NewDoubleLeast().SetFields([]builder.PostAggregator{}),
+		},
+		{
+			name:     "expression",
+			jsonData: `{"type":"expression"}`,
+			expected: NewExpression(),
+		},
+		{
+			name:     "fieldAccess",
+			jsonData: `{"type":"fieldAccess"}`,
+			expected: NewFieldAccess(),
+		},
+		{
+			name:     "finalizingFieldAccess",
+			jsonData: `{"type":"finalizingFieldAccess"}`,
+			expected: NewFinalizingFieldAccess(),
+		},
+		{
+			name:     "hyperUniqueFinalizing",
+			jsonData: `{"type":"hyperUniqueFinalizing"}`,
+			expected: NewHyperUniqueFinalizing(),
+		},
+		{
+			name:     "javascript",
+			jsonData: `{"type":"javascript"}`,
+			expected: NewJavascript(),
+		},
+		{
+			name:     "longGreatest",
+			jsonData: `{"type":"longGreatest"}`,
+			expected: NewLongGreatest().SetFields([]builder.PostAggregator{}),
+		},
+		{
+			name:     "longLeast",
+			jsonData: `{"type":"longLeast"}`,
+			expected: NewLongLeast().SetFields([]builder.PostAggregator{}),
+		},
+		{
+			name:     "quantileFromTDigestSketch",
+			jsonData: `{"type":"quantileFromTDigestSketch"}`,
+			expected: NewQuantileFromTDigestSketch(),
+		},
+		{
+			name:     "quantilesFromTDigestSketch",
+			jsonData: `{"type":"quantilesFromTDigestSketch"}`,
+			expected: NewQuantilesFromTDigestSketch(),
+		},
+		{
+			name:     "quantilesDoublesSketchToQuantile",
+			jsonData: `{"type":"quantilesDoublesSketchToQuantile"}`,
+			expected: NewQuantilesDoublesSketchToQuantile(),
+		},
+		{
+			name:     "quantilesDoublesSketchToQuantiles",
+			jsonData: `{"type":"quantilesDoublesSketchToQuantiles"}`,
+			expected: NewQuantilesDoublesSketchToQuantiles(),
+		},
+		{
+			name:     "quantilesDoublesSketchToHistogram",
+			jsonData: `{"type":"quantilesDoublesSketchToHistogram"}`,
+			expected: NewQuantilesDoublesSketchToHistogram(),
+		},
+		{
+			name:     "quantilesDoublesSketchToRank",
+			jsonData: `{"type":"quantilesDoublesSketchToRank"}`,
+			expected: NewQuantilesDoublesSketchToRank(),
+		},
+		{
+			name:     "quantilesDoublesSketchToCDF",
+			jsonData: `{"type":"quantilesDoublesSketchToCDF"}`,
+			expected: NewQuantilesDoublesSketchToCDF(),
+		},
+		{
+			name:     "quantilesDoublesSketchToString",
+			jsonData: `{"type":"quantilesDoublesSketchToString"}`,
+			expected: NewQuantilesDoublesSketchToString(),
+		},
+		{
+			name:     "unknown post aggregator",
+			jsonData: `{"type": "blahblahType"}`,
+			expected: builder.NewSpec("blahblahType"),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			a, err := Load([]byte(test.jsonData))
+
+			assert.NoErrorf(err, "loading a valid post aggregation should not fail")
+			assert.Equal(test.expected, a)
+		})
+	}
 }

--- a/builder/query/datasource_metadata.go
+++ b/builder/query/datasource_metadata.go
@@ -1,7 +1,7 @@
 package query
 
 import (
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type DataSourceMetadata struct {

--- a/builder/query/group_by.go
+++ b/builder/query/group_by.go
@@ -2,15 +2,16 @@ package query
 
 import (
 	"encoding/json"
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/aggregation"
-	"github.com/grafadruid/go-druid/builder/dimension"
-	"github.com/grafadruid/go-druid/builder/filter"
-	"github.com/grafadruid/go-druid/builder/granularity"
-	"github.com/grafadruid/go-druid/builder/havingspec"
-	"github.com/grafadruid/go-druid/builder/limitspec"
-	"github.com/grafadruid/go-druid/builder/postaggregation"
-	"github.com/grafadruid/go-druid/builder/virtualcolumn"
+
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/aggregation"
+	"github.com/adjoeio/go-druid/builder/dimension"
+	"github.com/adjoeio/go-druid/builder/filter"
+	"github.com/adjoeio/go-druid/builder/granularity"
+	"github.com/adjoeio/go-druid/builder/havingspec"
+	"github.com/adjoeio/go-druid/builder/limitspec"
+	"github.com/adjoeio/go-druid/builder/postaggregation"
+	"github.com/adjoeio/go-druid/builder/virtualcolumn"
 )
 
 type GroupBy struct {

--- a/builder/query/query.go
+++ b/builder/query/query.go
@@ -59,11 +59,11 @@ func (b *Base) UnmarshalJSON(data []byte) error {
 	}
 	if b.Type() != "sql" {
 		d, err := datasource.Load(tmp.DataSource)
+		if err != nil && d.Type() == "query" {
+			err = d.(*datasource.Query).UnmarshalJSONWithQueryLoader(tmp.DataSource, Load) // cycle import
+		}
 		if err != nil {
 			return err
-		}
-		if d.Type() == "query" {
-			d.(*datasource.Query).UnmarshalJSONWithQueryLoader(tmp.DataSource, Load)
 		}
 		b.DataSource = d
 		var i builder.Intervals

--- a/builder/query/query.go
+++ b/builder/query/query.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/datasource"
-	"github.com/grafadruid/go-druid/builder/intervals"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/datasource"
+	"github.com/adjoeio/go-druid/builder/intervals"
 )
 
 type Base struct {

--- a/builder/query/query_test.go
+++ b/builder/query/query_test.go
@@ -81,3 +81,25 @@ func TestAllSetterSQL(t *testing.T) {
 	assert.JSONEq(t, expected, string(expressionJSON))
 
 }
+
+func TestScanUnmarshalJson(t *testing.T) {
+	expected := `{
+    "queryType": "scan",
+    "dataSource": {
+      "type": "table",
+      "name": "A"
+    },
+    "columns": [
+      "AT"
+    ],
+    "intervals": {
+      "type": "intervals",
+      "intervals": [
+        "1980-06-12T22:30:00.000Z/2020-01-26T23:00:00.000Z"
+      ]
+    }
+  }`
+	scan := NewScan()
+	err := scan.UnmarshalJSON([]byte(expected))
+	assert.Nil(t, err)
+}

--- a/builder/query/scan.go
+++ b/builder/query/scan.go
@@ -3,9 +3,9 @@ package query
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/filter"
-	"github.com/grafadruid/go-druid/builder/virtualcolumn"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/filter"
+	"github.com/adjoeio/go-druid/builder/virtualcolumn"
 )
 
 type Order string
@@ -33,17 +33,18 @@ type Scan struct {
 
 // NewScan returns *builder.Scan which can be used to build a scan query.
 // Eg,
-//		table := datasource.NewTable().SetName("table-name")
 //
-//		now := time.Now()
-//		i := intervals.NewInterval().SetInterval(now.Add(-60*time.Minute), now)
-//		is := intervals.NewIntervals().SetIntervals([]*intervals.Interval{i})
+//	table := datasource.NewTable().SetName("table-name")
 //
-//		filter1 := filter.NewSelector().SetDimension("key1").SetValue("val1")
-//		filter2 := filter.NewSelector().SetDimension("key2").SetValue("val2")
-//		filters := filter.NewAnd().SetFields([]builder.Filter{filter1, filter2})
+//	now := time.Now()
+//	i := intervals.NewInterval().SetInterval(now.Add(-60*time.Minute), now)
+//	is := intervals.NewIntervals().SetIntervals([]*intervals.Interval{i})
 //
-//		ts := query.NewScan().SetDataSource(table).SetIntervals(is).SetFilter(filters).SetResultFormat("compactedList").SetLimit(10)
+//	filter1 := filter.NewSelector().SetDimension("key1").SetValue("val1")
+//	filter2 := filter.NewSelector().SetDimension("key2").SetValue("val2")
+//	filters := filter.NewAnd().SetFields([]builder.Filter{filter1, filter2})
+//
+//	ts := query.NewScan().SetDataSource(table).SetIntervals(is).SetFilter(filters).SetResultFormat("compactedList").SetLimit(10)
 func NewScan() *Scan {
 	s := &Scan{}
 	s.Base.SetQueryType("scan")

--- a/builder/query/search.go
+++ b/builder/query/search.go
@@ -2,12 +2,13 @@ package query
 
 import (
 	"encoding/json"
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/dimension"
-	"github.com/grafadruid/go-druid/builder/filter"
-	"github.com/grafadruid/go-druid/builder/granularity"
-	"github.com/grafadruid/go-druid/builder/searchqueryspec"
-	"github.com/grafadruid/go-druid/builder/types"
+
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/dimension"
+	"github.com/adjoeio/go-druid/builder/filter"
+	"github.com/adjoeio/go-druid/builder/granularity"
+	"github.com/adjoeio/go-druid/builder/searchqueryspec"
+	"github.com/adjoeio/go-druid/builder/types"
 )
 
 type SearchSortSpec struct {

--- a/builder/query/segment_metadata.go
+++ b/builder/query/segment_metadata.go
@@ -3,8 +3,8 @@ package query
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/toinclude"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/toinclude"
 )
 
 type AnalysisType string

--- a/builder/query/time_boundary.go
+++ b/builder/query/time_boundary.go
@@ -2,8 +2,9 @@ package query
 
 import (
 	"encoding/json"
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/filter"
+
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/filter"
 )
 
 type TimeBoundary struct {

--- a/builder/query/timeseries.go
+++ b/builder/query/timeseries.go
@@ -4,12 +4,12 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/aggregation"
-	"github.com/grafadruid/go-druid/builder/filter"
-	"github.com/grafadruid/go-druid/builder/granularity"
-	"github.com/grafadruid/go-druid/builder/postaggregation"
-	"github.com/grafadruid/go-druid/builder/virtualcolumn"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/aggregation"
+	"github.com/adjoeio/go-druid/builder/filter"
+	"github.com/adjoeio/go-druid/builder/granularity"
+	"github.com/adjoeio/go-druid/builder/postaggregation"
+	"github.com/adjoeio/go-druid/builder/virtualcolumn"
 )
 
 type Timeseries struct {

--- a/builder/query/top_n.go
+++ b/builder/query/top_n.go
@@ -2,14 +2,15 @@ package query
 
 import (
 	"encoding/json"
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/aggregation"
-	"github.com/grafadruid/go-druid/builder/dimension"
-	"github.com/grafadruid/go-druid/builder/filter"
-	"github.com/grafadruid/go-druid/builder/granularity"
-	"github.com/grafadruid/go-druid/builder/postaggregation"
-	"github.com/grafadruid/go-druid/builder/topnmetric"
-	"github.com/grafadruid/go-druid/builder/virtualcolumn"
+
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/aggregation"
+	"github.com/adjoeio/go-druid/builder/dimension"
+	"github.com/adjoeio/go-druid/builder/filter"
+	"github.com/adjoeio/go-druid/builder/granularity"
+	"github.com/adjoeio/go-druid/builder/postaggregation"
+	"github.com/adjoeio/go-druid/builder/topnmetric"
+	"github.com/adjoeio/go-druid/builder/virtualcolumn"
 )
 
 type TopN struct {

--- a/builder/searchqueryspec/search_query_spec.go
+++ b/builder/searchqueryspec/search_query_spec.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Base struct {

--- a/builder/spec.go
+++ b/builder/spec.go
@@ -1,0 +1,84 @@
+package builder
+
+import "encoding/json"
+
+type Spec struct {
+	Typ    ComponentType
+	Fields map[string]interface{}
+}
+
+func NewSpec(typ string) *Spec {
+	g := &Spec{Fields: make(map[string]interface{})}
+	g.SetType(typ)
+	return g
+}
+
+// Methods for compatibility
+
+func (g *Spec) Type() ComponentType {
+	return g.Typ
+}
+
+func (g *Spec) SetType(typ string) *Spec {
+	g.Typ = typ
+	return g
+}
+
+func (g *Spec) SetName(name string) *Spec {
+	g.SetField("name", name)
+	return g
+}
+
+// Generic methods
+
+func (g *Spec) SetField(name string, value interface{}) *Spec {
+	switch name {
+	case "type":
+		g.SetType(value.(ComponentType))
+	default:
+		g.Fields[name] = value
+	}
+	return g
+}
+
+func (g *Spec) SetFields(fields map[string]interface{}) *Spec {
+	if typ, present := fields["type"]; present {
+		g.SetType(typ.(ComponentType))
+		delete(fields, "type")
+	}
+
+	g.Fields = fields
+	return g
+}
+
+func (g *Spec) MergeFields(fields map[string]interface{}) *Spec {
+	for name, value := range fields {
+		g.SetField(name, value)
+	}
+	return g
+}
+
+func (g *Spec) MarshalJSON() ([]byte, error) {
+	// Reuse Fields map to avoid allocating a new one if it fits the capacity
+	if g.Typ != "" {
+		g.Fields["type"] = g.Typ
+	}
+
+	data, err := json.Marshal(&g.Fields)
+
+	delete(g.Fields, "type")
+
+	return data, err
+}
+
+func (g *Spec) UnmarshalJSON(bytes []byte) error {
+	err := json.Unmarshal(bytes, &g.Fields)
+
+	if typ, present := g.Fields["type"]; present {
+		g.Typ = typ.(ComponentType)
+	}
+
+	delete(g.Fields, "type")
+
+	return err
+}

--- a/builder/spec_test.go
+++ b/builder/spec_test.go
@@ -1,0 +1,84 @@
+package builder
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewSpec(t *testing.T) {
+	component := NewSpec("customComponent")
+
+	expected := `{"type":"customComponent"}`
+
+	componentJSON, err := json.Marshal(component)
+
+	assert.NoError(t, err)
+	assert.JSONEq(t, expected, string(componentJSON))
+}
+
+func TestSpec_SetField(t *testing.T) {
+	t.Run("common field", func(t *testing.T) {
+		withSpecificMethod := NewSpec("customComponent")
+		withSpecificMethod.
+			SetType("overriddenComponent").
+			SetName("op")
+
+		withSetFieldMethod := NewSpec("customComponent").
+			SetField("type", "overriddenComponent").
+			SetField("name", "op")
+
+		assert.Equal(t, withSpecificMethod, withSetFieldMethod)
+
+		expected := `{"type":"overriddenComponent","name":"op"}`
+
+		componentJSON, err := json.Marshal(withSetFieldMethod)
+
+		assert.NoError(t, err)
+		assert.JSONEq(t, expected, string(componentJSON))
+	})
+	t.Run("any field", func(t *testing.T) {
+		component := NewSpec("customComponent").SetField("foo", "bar")
+
+		expected := `{"type":"customComponent","foo":"bar"}`
+
+		componentJSON, err := json.Marshal(component)
+
+		assert.NoError(t, err)
+		assert.JSONEq(t, expected, string(componentJSON))
+	})
+}
+
+func TestSpec_MergeFields(t *testing.T) {
+	component := NewSpec("customComponent").
+		SetField("one", "direct").
+		SetField("two", "direct").
+		MergeFields(map[string]interface{}{
+			"two":   "merged",
+			"three": "merged",
+		})
+
+	expected := `{"type":"customComponent","one":"direct","two":"merged","three":"merged"}`
+
+	componentJSON, err := json.Marshal(component)
+
+	assert.NoError(t, err)
+	assert.JSONEq(t, expected, string(componentJSON))
+}
+
+func TestSpec_SetFields(t *testing.T) {
+	component := NewSpec("customComponent").
+		SetField("one", "direct").
+		SetField("two", "direct").
+		SetFields(map[string]interface{}{
+			"two":   "overridden",
+			"three": "overridden",
+		})
+
+	expected := `{"type":"customComponent","two":"overridden","three":"overridden"}`
+
+	componentJSON, err := json.Marshal(component)
+
+	assert.NoError(t, err)
+	assert.JSONEq(t, expected, string(componentJSON))
+}

--- a/builder/toinclude/to_include.go
+++ b/builder/toinclude/to_include.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Base struct {

--- a/builder/topnmetric/dimension.go
+++ b/builder/topnmetric/dimension.go
@@ -1,6 +1,6 @@
 package topnmetric
 
-import "github.com/grafadruid/go-druid/builder/types"
+import "github.com/adjoeio/go-druid/builder/types"
 
 type Dimension struct {
 	Base

--- a/builder/topnmetric/inverted.go
+++ b/builder/topnmetric/inverted.go
@@ -3,7 +3,7 @@ package topnmetric
 import (
 	"encoding/json"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Inverted struct {

--- a/builder/topnmetric/top_n_metric.go
+++ b/builder/topnmetric/top_n_metric.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Base struct {

--- a/builder/virtualcolumn/expression.go
+++ b/builder/virtualcolumn/expression.go
@@ -1,6 +1,6 @@
 package virtualcolumn
 
-import "github.com/grafadruid/go-druid/builder/types"
+import "github.com/adjoeio/go-druid/builder/types"
 
 type Expression struct {
 	Base

--- a/builder/virtualcolumn/expression_test.go
+++ b/builder/virtualcolumn/expression_test.go
@@ -2,9 +2,10 @@ package virtualcolumn
 
 import (
 	"encoding/json"
-	"github.com/grafadruid/go-druid/builder/types"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/adjoeio/go-druid/builder/types"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewExpression(t *testing.T) {

--- a/builder/virtualcolumn/virtual_column.go
+++ b/builder/virtualcolumn/virtual_column.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/grafadruid/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder"
 )
 
 type Base struct {

--- a/druid.go
+++ b/druid.go
@@ -212,7 +212,7 @@ func defaultRetry(ctx context.Context, resp *http.Response, err error) (bool, er
 		return true, nil
 	}
 
-	if resp.StatusCode == http.StatusOK {
+	if resp.StatusCode < http.StatusMultipleChoices {
 		return false, nil
 	}
 

--- a/druid.go
+++ b/druid.go
@@ -216,6 +216,11 @@ func defaultRetry(ctx context.Context, resp *http.Response, err error) (bool, er
 		return false, nil
 	}
 
+	switch resp.StatusCode {
+	case http.StatusGatewayTimeout:
+		return true, fmt.Errorf("gateway timeout")
+	}
+
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return true, fmt.Errorf("failed to read the response from Druid: %w", err)

--- a/examples/doublesSketchExample.go
+++ b/examples/doublesSketchExample.go
@@ -6,18 +6,19 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
-	"github.com/grafadruid/go-druid"
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/aggregation"
-	"github.com/grafadruid/go-druid/builder/datasource"
-	"github.com/grafadruid/go-druid/builder/dimension"
-	"github.com/grafadruid/go-druid/builder/granularity"
-	"github.com/grafadruid/go-druid/builder/intervals"
-	"github.com/grafadruid/go-druid/builder/postaggregation"
-	"github.com/grafadruid/go-druid/builder/query"
 	"log"
 	"time"
+
+	"github.com/adjoeio/go-druid"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/aggregation"
+	"github.com/adjoeio/go-druid/builder/datasource"
+	"github.com/adjoeio/go-druid/builder/dimension"
+	"github.com/adjoeio/go-druid/builder/granularity"
+	"github.com/adjoeio/go-druid/builder/intervals"
+	"github.com/adjoeio/go-druid/builder/postaggregation"
+	"github.com/adjoeio/go-druid/builder/query"
+	"github.com/davecgh/go-spew/spew"
 )
 
 func getConnection() *druid.Client {

--- a/examples/fromjson/main.go
+++ b/examples/fromjson/main.go
@@ -1,15 +1,12 @@
-//go:build mage
-// +build mage
-
 package main
 
 import (
 	"fmt"
+	"github.com/grafadruid/go-druid"
+	"github.com/grafadruid/go-druid/builder"
 	"log"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/grafadruid/go-druid"
-	"github.com/grafadruid/go-druid/builder"
 )
 
 func loadAndExecute(d *druid.Client, qry []byte) {
@@ -54,8 +51,8 @@ func main() {
 	loadAndExecute(d, []byte(qry))
 
 	// https://github.com/grafadruid/go-druid/issues/15
-	qry = `{"batchSize":20480,"columns":["__time","channel","cityName","comment","count","countryIsoCode","diffUrl","flags","isAnonymous","isMinor","isNew","isRobot","isUnpatrolled","metroCode","namespace","page","regionIsoCode","regionName","sum_added","sum_commentLength","sum_deleted","sum_delta","sum_deltaBucket","user"],"dataSource":{"type":"query","query":{"queryType":"scan","dataSource":{"type":"table","name":"A"},"columns":["AT"],"intervals":{"type":"intervals","intervals":["1980-06-12T22:30:00.000Z/2020-01-26T23:00:00.000Z"]}}},"filter":{"dimension":"countryName","extractionFn":{"locale":"","type":"lower"},"type":"selector","value":"france"},"intervals":{"type":"intervals","intervals":["1980-06-12T22:30:00.000Z/2020-01-26T23:00:00.000Z"]},"limit":10,"order":"descending","queryType":"scan"}`
-	//loadAndExecute(d, []byte(qry))
+	qry = `{"batchSize":20480,"columns":["__time","channel","cityName","comment","count","countryIsoCode","diffUrl","flags","isAnonymous","isMinor","isNew","isRobot","isUnpatrolled","metroCode","namespace","page","regionIsoCode","regionName","sum_added","sum_commentLength","sum_deleted","sum_delta","sum_deltaBucket","user"],"dataSource":{"type":"query","query":{"queryType":"scan","dataSource":{"type":"table","name":"A"},"columns":["AT"],"intervals":{"type":"intervals","intervals":["1980-06-12T22:30:00.000Z/2020-01-26T23:00:00.000Z"]}}},"filter":{"dimension":"countryName","extractionFn":{"locale":"","type":"lower"},"type":"selector","value":"france"},"intervals":{"type":"intervals","intervals":["1980-06-12T22:30:00.000Z/2020-01-26T23:00:00.000Z"]},"limit":10,"order":"none","queryType":"scan"}`
+	loadAndExecute(d, []byte(qry))
 
 	qry = `{"context":{"con":"text"},"query":"SELECT * \nFROM \"wikipedia\"\nWHERE \"countryName\" = 'France'\nLIMIT 10","queryType":"sql", "resultFormat":"array", "header": true}`
 	loadAndExecute(d, []byte(qry))

--- a/examples/fromjson/main.go
+++ b/examples/fromjson/main.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/grafadruid/go-druid"
-	"github.com/grafadruid/go-druid/builder"
 	"log"
 
+	"github.com/adjoeio/go-druid"
+	"github.com/adjoeio/go-druid/builder"
 	"github.com/davecgh/go-spew/spew"
 )
 
@@ -50,7 +50,7 @@ func main() {
 	qry = `{"batchSize":20480,"columns":["__time","channel","cityName","comment","count","countryIsoCode","diffUrl","flags","isAnonymous","isMinor","isNew","isRobot","isUnpatrolled","metroCode","namespace","page","regionIsoCode","regionName","sum_added","sum_commentLength","sum_deleted","sum_delta","sum_deltaBucket","user"],"dataSource":{"name":"wikipedia","type":"table"},"filter":{"dimension":"countryName","extractionFn":{"locale":"","type":"lower"},"type":"selector","value":"france"},"intervals":{"type":"intervals","intervals":["1980-06-12T22:30:00.000Z/2020-01-26T23:00:00.000Z"]},"limit":10,"order":"descending","queryType":"scan", "resultFormat":"compactedList"}`
 	loadAndExecute(d, []byte(qry))
 
-	// https://github.com/grafadruid/go-druid/issues/15
+	// https://github.com/adjoeio/go-druid/issues/15
 	qry = `{"batchSize":20480,"columns":["__time","channel","cityName","comment","count","countryIsoCode","diffUrl","flags","isAnonymous","isMinor","isNew","isRobot","isUnpatrolled","metroCode","namespace","page","regionIsoCode","regionName","sum_added","sum_commentLength","sum_deleted","sum_delta","sum_deltaBucket","user"],"dataSource":{"type":"query","query":{"queryType":"scan","dataSource":{"type":"table","name":"A"},"columns":["AT"],"intervals":{"type":"intervals","intervals":["1980-06-12T22:30:00.000Z/2020-01-26T23:00:00.000Z"]}}},"filter":{"dimension":"countryName","extractionFn":{"locale":"","type":"lower"},"type":"selector","value":"france"},"intervals":{"type":"intervals","intervals":["1980-06-12T22:30:00.000Z/2020-01-26T23:00:00.000Z"]},"limit":10,"order":"none","queryType":"scan"}`
 	loadAndExecute(d, []byte(qry))
 

--- a/examples/main.go
+++ b/examples/main.go
@@ -8,16 +8,15 @@ import (
 	"log"
 	"time"
 
-	"github.com/grafadruid/go-druid/builder/intervals"
-
+	"github.com/adjoeio/go-druid"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/aggregation"
+	"github.com/adjoeio/go-druid/builder/datasource"
+	"github.com/adjoeio/go-druid/builder/filter"
+	"github.com/adjoeio/go-druid/builder/granularity"
+	"github.com/adjoeio/go-druid/builder/intervals"
+	"github.com/adjoeio/go-druid/builder/query"
 	"github.com/davecgh/go-spew/spew"
-	"github.com/grafadruid/go-druid"
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/aggregation"
-	"github.com/grafadruid/go-druid/builder/datasource"
-	"github.com/grafadruid/go-druid/builder/filter"
-	"github.com/grafadruid/go-druid/builder/granularity"
-	"github.com/grafadruid/go-druid/builder/query"
 )
 
 func main() {

--- a/examples/querySqlExample.go
+++ b/examples/querySqlExample.go
@@ -4,10 +4,11 @@
 package main
 
 import (
-	"github.com/davecgh/go-spew/spew"
-	"github.com/grafadruid/go-druid"
-	"github.com/grafadruid/go-druid/builder/query"
 	"log"
+
+	"github.com/adjoeio/go-druid"
+	"github.com/adjoeio/go-druid/builder/query"
+	"github.com/davecgh/go-spew/spew"
 )
 
 func main() {

--- a/examples/subqueryExample.go
+++ b/examples/subqueryExample.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"github.com/davecgh/go-spew/spew"
+	"github.com/grafadruid/go-druid"
+	"github.com/grafadruid/go-druid/builder"
+	"github.com/grafadruid/go-druid/builder/aggregation"
+	datasource2 "github.com/grafadruid/go-druid/builder/datasource"
+	"github.com/grafadruid/go-druid/builder/dimension"
+	"github.com/grafadruid/go-druid/builder/extractionfn"
+	"github.com/grafadruid/go-druid/builder/filter"
+	"github.com/grafadruid/go-druid/builder/granularity"
+	"github.com/grafadruid/go-druid/builder/intervals"
+	"github.com/grafadruid/go-druid/builder/query"
+	"github.com/grafadruid/go-druid/builder/topnmetric"
+	"log"
+	"time"
+)
+
+func main() {
+
+	d, err := druid.NewClient("http://localhost:8888")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var results []map[string]interface{}
+
+	_, err = d.Query().Execute(MakeScanSubQuery(), &results)
+	if err != nil {
+		log.Fatal(err)
+	}
+	spew.Dump(results)
+
+	_, err = d.Query().Execute(MakeTimeSeriesSubQuery(), &results)
+	if err != nil {
+		log.Fatal(err)
+	}
+	spew.Dump(results)
+
+}
+
+// MakeScanSubQuery Result is nil
+func MakeScanSubQuery() *query.Scan {
+	location, _ := time.LoadLocation("UTC")
+
+	start, _ := time.ParseInLocation(time.RFC3339Nano,
+		"1980-06-12T22:30:00.000Z",
+		location)
+	end, _ := time.ParseInLocation(time.RFC3339Nano,
+		"2023-01-26T23:00:00.000Z",
+		location)
+	i := intervals.NewInterval()
+	i.SetInterval(start, end)
+	interval := intervals.NewIntervals().SetIntervals([]*intervals.Interval{i})
+
+	selectorExtractionFn := extractionfn.NewLower().SetLocale("")
+	a := filter.NewSelector().SetDimension("countryName").SetValue("france").
+		SetExtractionFn(selectorExtractionFn)
+	query.NewSegmentMetadata().SetIntervals(interval)
+	datasourceSubQuery := query.NewScan().
+		SetDataSource(datasource2.NewTable().SetName("A")).SetColumns([]string{"AT"}).
+		SetIntervals(interval)
+	datasource := datasource2.NewQuery().SetQuery(datasourceSubQuery)
+	scan := query.NewScan()
+	queryTest := scan.SetLimit(10).SetIntervals(interval).SetFilter(a).
+		SetColumns([]string{"__time", "channel", "cityName", "comment", "count", "countryIsoCode",
+			"diffUrl", "flags", "isAnonymous", "isMinor", "isNew", "isRobot", "isUnpatrolled",
+			"metroCode", "namespace", "page", "regionIsoCode", "regionName", "sum_added",
+			"sum_commentLength", "sum_deleted", "sum_delta", "sum_deltaBucket", "user"}).
+		SetBatchSize(20480).
+		SetDataSource(datasource).SetOrder(query.None)
+	return queryTest
+}
+
+// MakeTimeSeriesSubQuery Results are timestamp 2022-10-07 ~ 13
+func MakeTimeSeriesSubQuery() *query.Timeseries {
+	location, _ := time.LoadLocation("UTC")
+	start, _ := time.ParseInLocation(time.RFC3339,
+		"2022-10-07T00:00:00Z",
+		location)
+	i := intervals.NewInterval()
+	i.SetInterval(start, start.Add(time.Hour*24*7))
+	interval := intervals.NewIntervals().SetIntervals([]*intervals.Interval{i})
+	topN := query.NewTopN().
+		SetThreshold(100).
+		SetMetric(topnmetric.NewNumeric().SetMetric("count")).
+		SetIntervals(interval).
+		SetGranularity(granularity.NewSimple().SetGranularity(granularity.Day)).
+		SetDimension(dimension.NewDefault().SetDimension("string_value")).
+		SetDataSource(datasource2.NewTable().SetName("dc_94b4f5fdfde940979b79c50539d8322a_b42fde98efed4e638a0016b34b3c10cf_dataset_pre")).
+		SetAggregations([]builder.Aggregator{aggregation.NewLongSum().SetName("count").SetFieldName("count")}).
+		SetFilter(filter.NewAnd().SetFields([]builder.Filter{filter.NewSelector().SetDimension("_split_name_").SetValue("train"),
+			filter.NewSelector().SetDimension("column_name").SetValue("addressState")}))
+	subQuery := datasource2.NewQuery().SetQuery(topN)
+	queryTest := query.NewTimeseries().SetGranularity(granularity.NewSimple().SetGranularity(granularity.Day)).
+		SetIntervals(interval).SetDataSource(subQuery)
+	return queryTest
+}

--- a/examples/subqueryExample.go
+++ b/examples/subqueryExample.go
@@ -1,24 +1,24 @@
 package main
 
 import (
-	"github.com/davecgh/go-spew/spew"
-	"github.com/grafadruid/go-druid"
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/aggregation"
-	datasource2 "github.com/grafadruid/go-druid/builder/datasource"
-	"github.com/grafadruid/go-druid/builder/dimension"
-	"github.com/grafadruid/go-druid/builder/extractionfn"
-	"github.com/grafadruid/go-druid/builder/filter"
-	"github.com/grafadruid/go-druid/builder/granularity"
-	"github.com/grafadruid/go-druid/builder/intervals"
-	"github.com/grafadruid/go-druid/builder/query"
-	"github.com/grafadruid/go-druid/builder/topnmetric"
 	"log"
 	"time"
+
+	"github.com/adjoeio/go-druid"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/aggregation"
+	datasource2 "github.com/adjoeio/go-druid/builder/datasource"
+	"github.com/adjoeio/go-druid/builder/dimension"
+	"github.com/adjoeio/go-druid/builder/extractionfn"
+	"github.com/adjoeio/go-druid/builder/filter"
+	"github.com/adjoeio/go-druid/builder/granularity"
+	"github.com/adjoeio/go-druid/builder/intervals"
+	"github.com/adjoeio/go-druid/builder/query"
+	"github.com/adjoeio/go-druid/builder/topnmetric"
+	"github.com/davecgh/go-spew/spew"
 )
 
 func main() {
-
 	d, err := druid.NewClient("http://localhost:8888")
 	if err != nil {
 		log.Fatal(err)
@@ -37,7 +37,6 @@ func main() {
 		log.Fatal(err)
 	}
 	spew.Dump(results)
-
 }
 
 // MakeScanSubQuery Result is nil
@@ -64,10 +63,12 @@ func MakeScanSubQuery() *query.Scan {
 	datasource := datasource2.NewQuery().SetQuery(datasourceSubQuery)
 	scan := query.NewScan()
 	queryTest := scan.SetLimit(10).SetIntervals(interval).SetFilter(a).
-		SetColumns([]string{"__time", "channel", "cityName", "comment", "count", "countryIsoCode",
+		SetColumns([]string{
+			"__time", "channel", "cityName", "comment", "count", "countryIsoCode",
 			"diffUrl", "flags", "isAnonymous", "isMinor", "isNew", "isRobot", "isUnpatrolled",
 			"metroCode", "namespace", "page", "regionIsoCode", "regionName", "sum_added",
-			"sum_commentLength", "sum_deleted", "sum_delta", "sum_deltaBucket", "user"}).
+			"sum_commentLength", "sum_deleted", "sum_delta", "sum_deltaBucket", "user",
+		}).
 		SetBatchSize(20480).
 		SetDataSource(datasource).SetOrder(query.None)
 	return queryTest
@@ -90,8 +91,10 @@ func MakeTimeSeriesSubQuery() *query.Timeseries {
 		SetDimension(dimension.NewDefault().SetDimension("string_value")).
 		SetDataSource(datasource2.NewTable().SetName("dc_94b4f5fdfde940979b79c50539d8322a_b42fde98efed4e638a0016b34b3c10cf_dataset_pre")).
 		SetAggregations([]builder.Aggregator{aggregation.NewLongSum().SetName("count").SetFieldName("count")}).
-		SetFilter(filter.NewAnd().SetFields([]builder.Filter{filter.NewSelector().SetDimension("_split_name_").SetValue("train"),
-			filter.NewSelector().SetDimension("column_name").SetValue("addressState")}))
+		SetFilter(filter.NewAnd().SetFields([]builder.Filter{
+			filter.NewSelector().SetDimension("_split_name_").SetValue("train"),
+			filter.NewSelector().SetDimension("column_name").SetValue("addressState"),
+		}))
 	subQuery := datasource2.NewQuery().SetQuery(topN)
 	queryTest := query.NewTimeseries().SetGranularity(granularity.NewSimple().SetGranularity(granularity.Day)).
 		SetIntervals(interval).SetDataSource(subQuery)

--- a/examples/subquery_test.go
+++ b/examples/subquery_test.go
@@ -2,19 +2,20 @@ package main
 
 import (
 	"encoding/json"
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/aggregation"
-	datasource2 "github.com/grafadruid/go-druid/builder/datasource"
-	"github.com/grafadruid/go-druid/builder/dimension"
-	"github.com/grafadruid/go-druid/builder/extractionfn"
-	"github.com/grafadruid/go-druid/builder/filter"
-	"github.com/grafadruid/go-druid/builder/granularity"
-	"github.com/grafadruid/go-druid/builder/intervals"
-	"github.com/grafadruid/go-druid/builder/query"
-	"github.com/grafadruid/go-druid/builder/topnmetric"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/aggregation"
+	datasource2 "github.com/adjoeio/go-druid/builder/datasource"
+	"github.com/adjoeio/go-druid/builder/dimension"
+	"github.com/adjoeio/go-druid/builder/extractionfn"
+	"github.com/adjoeio/go-druid/builder/filter"
+	"github.com/adjoeio/go-druid/builder/granularity"
+	"github.com/adjoeio/go-druid/builder/intervals"
+	"github.com/adjoeio/go-druid/builder/query"
+	"github.com/adjoeio/go-druid/builder/topnmetric"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSubQueryScan(t *testing.T) {
@@ -105,10 +106,12 @@ func TestSubQueryScan(t *testing.T) {
 	datasource := datasource2.NewQuery().SetQuery(datasourceSubQuery)
 	scan := query.NewScan()
 	queryTest := scan.SetOrder(query.None).SetLimit(10).SetIntervals(interval).SetFilter(a).
-		SetColumns([]string{"__time", "channel", "cityName", "comment", "count", "countryIsoCode",
+		SetColumns([]string{
+			"__time", "channel", "cityName", "comment", "count", "countryIsoCode",
 			"diffUrl", "flags", "isAnonymous", "isMinor", "isNew", "isRobot", "isUnpatrolled",
 			"metroCode", "namespace", "page", "regionIsoCode", "regionName", "sum_added",
-			"sum_commentLength", "sum_deleted", "sum_delta", "sum_deltaBucket", "user"}).
+			"sum_commentLength", "sum_deleted", "sum_delta", "sum_deltaBucket", "user",
+		}).
 		SetBatchSize(20480).
 		SetDataSource(datasource)
 
@@ -189,8 +192,10 @@ func TestSubQueryTimeseries(t *testing.T) {
 		SetDimension(dimension.NewDefault().SetDimension("string_value")).
 		SetDataSource(datasource2.NewTable().SetName("dc_94b4f5fdfde940979b79c50539d8322a_b42fde98efed4e638a0016b34b3c10cf_dataset_pre")).
 		SetAggregations([]builder.Aggregator{aggregation.NewLongSum().SetName("count").SetFieldName("count")}).
-		SetFilter(filter.NewAnd().SetFields([]builder.Filter{filter.NewSelector().SetDimension("_split_name_").SetValue("train"),
-			filter.NewSelector().SetDimension("column_name").SetValue("addressState")}))
+		SetFilter(filter.NewAnd().SetFields([]builder.Filter{
+			filter.NewSelector().SetDimension("_split_name_").SetValue("train"),
+			filter.NewSelector().SetDimension("column_name").SetValue("addressState"),
+		}))
 	subQuery := datasource2.NewQuery().SetQuery(topN)
 	queryTest := query.NewTimeseries().SetGranularity(granularity.NewSimple().SetGranularity(granularity.Day)).
 		SetIntervals(interval).SetDataSource(subQuery)
@@ -199,7 +204,6 @@ func TestSubQueryTimeseries(t *testing.T) {
 	assert.Nil(t, err)
 
 	assert.JSONEq(t, expected, string(queryTestJSON))
-
 }
 
 func TestDiffBuilderAndString(t *testing.T) {

--- a/examples/subquery_test.go
+++ b/examples/subquery_test.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/grafadruid/go-druid/builder"
+	"github.com/grafadruid/go-druid/builder/aggregation"
+	datasource2 "github.com/grafadruid/go-druid/builder/datasource"
+	"github.com/grafadruid/go-druid/builder/dimension"
+	"github.com/grafadruid/go-druid/builder/extractionfn"
+	"github.com/grafadruid/go-druid/builder/filter"
+	"github.com/grafadruid/go-druid/builder/granularity"
+	"github.com/grafadruid/go-druid/builder/intervals"
+	"github.com/grafadruid/go-druid/builder/query"
+	"github.com/grafadruid/go-druid/builder/topnmetric"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+func TestSubQueryScan(t *testing.T) {
+	expected := `{
+  "batchSize": 20480,
+  "columns": [
+    "__time",
+    "channel",
+    "cityName",
+    "comment",
+    "count",
+    "countryIsoCode",
+    "diffUrl",
+    "flags",
+    "isAnonymous",
+    "isMinor",
+    "isNew",
+    "isRobot",
+    "isUnpatrolled",
+    "metroCode",
+    "namespace",
+    "page",
+    "regionIsoCode",
+    "regionName",
+    "sum_added",
+    "sum_commentLength",
+    "sum_deleted",
+    "sum_delta",
+    "sum_deltaBucket",
+    "user"
+  ],
+  "dataSource": {
+    "type": "query",
+    "query": {
+      "queryType": "scan",
+      "dataSource": {
+        "type": "table",
+        "name": "A"
+      },
+      "columns": [
+        "AT"
+      ],
+      "intervals": {
+        "type": "intervals",
+        "intervals": [
+          "1980-06-12T22:30:00Z/2020-01-26T23:00:00Z"
+        ]
+      }
+    }
+  },
+  "filter": {
+    "dimension": "countryName",
+    "extractionFn": {
+      "type": "lower"
+    },
+    "type": "selector",
+    "value": "france"
+  },
+  "intervals": {
+    "type": "intervals",
+    "intervals": [
+      "1980-06-12T22:30:00Z/2020-01-26T23:00:00Z"
+    ]
+  },
+  "limit": 10,
+  "order": "NONE",
+  "queryType": "scan"
+}`
+	location, _ := time.LoadLocation("UTC")
+
+	start, _ := time.ParseInLocation(time.RFC3339Nano,
+		"1980-06-12T22:30:00.000Z",
+		location)
+	end, _ := time.ParseInLocation(time.RFC3339Nano,
+		"2020-01-26T23:00:00.000Z",
+		location)
+	i := intervals.NewInterval()
+	i.SetInterval(start, end)
+	interval := intervals.NewIntervals().SetIntervals([]*intervals.Interval{i})
+
+	selectorExtractionFn := extractionfn.NewLower().SetLocale("")
+	a := filter.NewSelector().SetDimension("countryName").SetValue("france").
+		SetExtractionFn(selectorExtractionFn)
+
+	datasourceSubQuery := query.NewScan().
+		SetDataSource(datasource2.NewTable().SetName("A")).SetColumns([]string{"AT"}).
+		SetIntervals(interval)
+	datasource := datasource2.NewQuery().SetQuery(datasourceSubQuery)
+	scan := query.NewScan()
+	queryTest := scan.SetOrder(query.None).SetLimit(10).SetIntervals(interval).SetFilter(a).
+		SetColumns([]string{"__time", "channel", "cityName", "comment", "count", "countryIsoCode",
+			"diffUrl", "flags", "isAnonymous", "isMinor", "isNew", "isRobot", "isUnpatrolled",
+			"metroCode", "namespace", "page", "regionIsoCode", "regionName", "sum_added",
+			"sum_commentLength", "sum_deleted", "sum_delta", "sum_deltaBucket", "user"}).
+		SetBatchSize(20480).
+		SetDataSource(datasource)
+
+	queryTestJSON, err := json.Marshal(queryTest)
+	assert.Nil(t, err)
+
+	assert.JSONEq(t, expected, string(queryTestJSON))
+}
+
+func TestSubQueryTimeseries(t *testing.T) {
+	expected := `{
+	"dataSource": {
+		"query": {
+			"aggregations": [{
+				"fieldName": "count",
+				"name": "count",
+				"type": "longSum"
+			}],
+			"dataSource": {
+				"name": "dc_94b4f5fdfde940979b79c50539d8322a_b42fde98efed4e638a0016b34b3c10cf_dataset_pre",
+				"type": "table"
+			},
+			"dimension": {
+				"dimension": "string_value",
+				"type": "default"
+			},
+			"filter": {
+				"fields": [{
+						"dimension": "_split_name_",
+						"type": "selector",
+						"value": "train"
+					},
+					{
+						"dimension": "column_name",
+						"type": "selector",
+						"value": "addressState"
+					}
+				],
+				"type": "and"
+			},
+			"granularity": "day",
+			"intervals": {
+				"intervals": [
+					"2022-10-07T00:00:00Z/2022-10-14T00:00:00Z"
+				],
+				"type": "intervals"
+			},
+			"metric": {
+				"metric": "count",
+				"type": "numeric"
+			},
+			"queryType": "topN",
+			"threshold": 100
+		},
+		"type": "query"
+	},
+	"granularity": "day",
+	"intervals": {
+		"intervals": [
+			"2022-10-07T00:00:00Z/2022-10-14T00:00:00Z"
+		],
+		"type": "intervals"
+	},
+	"queryType": "timeseries"
+}`
+	location, _ := time.LoadLocation("UTC")
+	start, _ := time.ParseInLocation(time.RFC3339,
+		"2022-10-07T00:00:00Z",
+		location)
+	i := intervals.NewInterval()
+	i.SetInterval(start, start.Add(time.Hour*24*7))
+	interval := intervals.NewIntervals().SetIntervals([]*intervals.Interval{i})
+	topN := query.NewTopN().
+		SetThreshold(100).
+		SetMetric(topnmetric.NewNumeric().SetMetric("count")).
+		SetIntervals(interval).
+		SetGranularity(granularity.NewSimple().SetGranularity(granularity.Day)).
+		SetDimension(dimension.NewDefault().SetDimension("string_value")).
+		SetDataSource(datasource2.NewTable().SetName("dc_94b4f5fdfde940979b79c50539d8322a_b42fde98efed4e638a0016b34b3c10cf_dataset_pre")).
+		SetAggregations([]builder.Aggregator{aggregation.NewLongSum().SetName("count").SetFieldName("count")}).
+		SetFilter(filter.NewAnd().SetFields([]builder.Filter{filter.NewSelector().SetDimension("_split_name_").SetValue("train"),
+			filter.NewSelector().SetDimension("column_name").SetValue("addressState")}))
+	subQuery := datasource2.NewQuery().SetQuery(topN)
+	queryTest := query.NewTimeseries().SetGranularity(granularity.NewSimple().SetGranularity(granularity.Day)).
+		SetIntervals(interval).SetDataSource(subQuery)
+
+	queryTestJSON, err := json.Marshal(queryTest)
+	assert.Nil(t, err)
+
+	assert.JSONEq(t, expected, string(queryTestJSON))
+
+}
+
+func TestDiffBuilderAndString(t *testing.T) {
+	expected := `{"type":"query","query":{"queryType":"scan","dataSource":{"type":"table","name":"A"},"columns":["AT"],"intervals":{"type":"intervals","intervals":["1980-06-12T22:30:00Z/2020-01-26T23:00:00Z"]}}}`
+
+	location, _ := time.LoadLocation("UTC")
+
+	start, _ := time.ParseInLocation(time.RFC3339Nano,
+		"1980-06-12T22:30:00.000Z",
+		location)
+	end, _ := time.ParseInLocation(time.RFC3339Nano,
+		"2020-01-26T23:00:00.000Z",
+		location)
+	i := intervals.NewInterval()
+	i.SetInterval(start, end)
+	interval := intervals.NewIntervals().SetIntervals([]*intervals.Interval{i})
+
+	datasourceSubQuery := query.NewScan().
+		SetDataSource(datasource2.NewTable().SetName("A")).SetColumns([]string{"AT"}).
+		SetIntervals(interval)
+
+	datasource := datasource2.NewQuery().SetQuery(datasourceSubQuery)
+
+	expressionJSON, err := json.Marshal(datasource)
+	assert.Nil(t, err)
+	assert.JSONEq(t, expected, string(expressionJSON))
+}

--- a/examples/tdigestExample.go
+++ b/examples/tdigestExample.go
@@ -5,17 +5,18 @@ package main
 
 import (
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
-	"github.com/grafadruid/go-druid"
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/aggregation"
-	"github.com/grafadruid/go-druid/builder/datasource"
-	"github.com/grafadruid/go-druid/builder/granularity"
-	"github.com/grafadruid/go-druid/builder/intervals"
-	"github.com/grafadruid/go-druid/builder/postaggregation"
-	"github.com/grafadruid/go-druid/builder/query"
 	"log"
 	"time"
+
+	"github.com/adjoeio/go-druid"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/aggregation"
+	"github.com/adjoeio/go-druid/builder/datasource"
+	"github.com/adjoeio/go-druid/builder/granularity"
+	"github.com/adjoeio/go-druid/builder/intervals"
+	"github.com/adjoeio/go-druid/builder/postaggregation"
+	"github.com/adjoeio/go-druid/builder/query"
+	"github.com/davecgh/go-spew/spew"
 )
 
 func getConnection() *druid.Client {
@@ -51,7 +52,7 @@ func tdigestSketchQuantilesPostAggUsingBuilder() {
 	atds := aggregation.NewTDigestSketch().SetName("merged_sketch").SetFieldName("valuesTDS")
 	a := []builder.Aggregator{atds}
 
-	//TDigest Post Aggregation Quantiles
+	// TDigest Post Aggregation Quantiles
 	qf := postaggregation.NewQuantilesFromTDigestSketchField().
 		SetType("fieldAccess").
 		SetFieldName("merged_sketch")
@@ -86,7 +87,7 @@ func tdigestSketchQuantilePostAggUsingBuilder() {
 	atds := aggregation.NewTDigestSketch().SetName("merged_sketch").SetFieldName("valuesTDS")
 	a := []builder.Aggregator{atds}
 
-	//TDigest Post Aggregation Quantile
+	// TDigest Post Aggregation Quantile
 	qf := postaggregation.NewQuantileFromTDigestSketchField().
 		SetType("fieldAccess").
 		SetFieldName("merged_sketch")

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/grafadruid/go-druid
+module github.com/adjoeio/go-druid
 
 go 1.14
 

--- a/query.go
+++ b/query.go
@@ -3,8 +3,8 @@ package druid
 import (
 	"net/http"
 
-	"github.com/grafadruid/go-druid/builder"
-	"github.com/grafadruid/go-druid/builder/query"
+	"github.com/adjoeio/go-druid/builder"
+	"github.com/adjoeio/go-druid/builder/query"
 )
 
 const (
@@ -42,10 +42,9 @@ func (q *QueryService) Execute(qry builder.Query, result interface{}, headers ..
 	return resp, nil
 }
 
-//func (q *QueryService) Cancel(query builder.Query) () {}
+// func (q *QueryService) Cancel(query builder.Query) () {}
 
-//func (q *QueryService) Candidates(query builder.Query, result interface{}) (*Response, error) {}
-
+// func (q *QueryService) Candidates(query builder.Query, result interface{}) (*Response, error) {}
 func (q *QueryService) Load(data []byte) (builder.Query, error) {
 	return query.Load(data)
 }


### PR DESCRIPTION
There are some cases when Druid is having the gateway timeout with an HTTP 504 status code when the heavy requests take more than 1 minute to be processed. In this case the response is an HTML with a following payload:
```
<html>

<head>
    <title>504 Gateway Time-out</title>
</head>

<body>
    <center>
        <h1>504 Gateway Time-out</h1>
    </center>
</body>

</html>
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
<!-- a padding to disable MSIE and Chrome friendly error page -->
```

This cannot be unmarshaled to the proper JSON structure making the error message unnecessarily long. So this case should be separately handled.